### PR TITLE
Code changes to return all the SP-API request responses when calling …

### DIFF
--- a/use-cases/listings/app/__tests__/api/subscriptions/__snapshots__/route.test.ts.snap
+++ b/use-cases/listings/app/__tests__/api/subscriptions/__snapshots__/route.test.ts.snap
@@ -37,47 +37,13 @@ exports[`Test for the subscriptions API Test for the POST subscriptions API retu
 
 exports[`Test for the subscriptions API Test for the POST subscriptions API returns 200 on successful case from create new destination 1`] = `
 {
-  "debugContext": [
-    {
-      "apiDocumentationLink": "https://developer-docs.amazon.com/sp-api/docs/notifications-api-v1-reference#createsubscription",
-      "apiName": "CreateSubscription",
-      "request": {
-        "body": {
-          "destinationId": "testDestinationId",
-          "payloadVersion": "1",
-        },
-        "notificationType": "LISTINGS_ITEM_STATUS_CHANGE",
-      },
-      "response": {
-        "destinationId": "testDestinationId",
-        "payloadVersion": "1.0",
-        "subscriptionId": "510f082f-a853-4847-acf2-475641cb7b06",
-      },
-    },
-  ],
+  "debugContext": [],
 }
 `;
 
 exports[`Test for the subscriptions API Test for the POST subscriptions API returns 200 on successful case from existing destination 1`] = `
 {
-  "debugContext": [
-    {
-      "apiDocumentationLink": "https://developer-docs.amazon.com/sp-api/docs/notifications-api-v1-reference#createsubscription",
-      "apiName": "CreateSubscription",
-      "request": {
-        "body": {
-          "destinationId": "testDestinationId",
-          "payloadVersion": "1",
-        },
-        "notificationType": "LISTINGS_ITEM_STATUS_CHANGE",
-      },
-      "response": {
-        "destinationId": "testDestinationId",
-        "payloadVersion": "1.0",
-        "subscriptionId": "510f082f-a853-4847-acf2-475641cb7b06",
-      },
-    },
-  ],
+  "debugContext": [],
 }
 `;
 

--- a/use-cases/listings/app/api/subscriptions/route.ts
+++ b/use-cases/listings/app/api/subscriptions/route.ts
@@ -207,7 +207,7 @@ async function createSubscriptionHandler(settings: Settings) {
       "OK",
       serializeToJsonString({
         data: createSubscriptionResponse.payload,
-        debugContext: [createSubscriptionSPAPIResponse],
+        debugContext: reqResponses,
       }),
     );
   } catch (error) {


### PR DESCRIPTION
…CreateSubscription workflow

*Issue #, if available:*

*Description of changes:*

Right now, the Create Subscription workflow only shows the debug context for the Create Subscription SP-API. With this fix, the create subscription workflow shows the debug context for all the SP API calls.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
