### PR TITLE
Improve deployment scripts to support Windows/Git Bash users

### DIFF
--- a/use-cases/data-kiosk/README.md
+++ b/use-cases/data-kiosk/README.md
@@ -42,6 +42,8 @@ The pre-requisites for deploying the Sample Solution App to the AWS cloud are:
 * [Maven](https://maven.apache.org/)
   * Just for deploying a Java-based application.
   * If not present, it will be installed as part of the deployment script.
+* [GitBash](https://git-scm.com/download/win)
+    * in case you use Windows in order to run the deployment script.
   
 
 ## Usage
@@ -129,8 +131,8 @@ The deployment script will create a Sample Solution App in the AWS cloud.
 To execute the deployment script, follow the steps below.
 1. Identify the deployment script for the programming language you want for your Sample Solution App.
     1. For example, for the Python application the file is [app/scripts/python/python-app.sh](app/scripts/python/python-app.sh).
-2. Execute the script from your terminal.
-    1. For example, to execute the Python deployment script in a Unix-based system, run `bash python-app.sh`.
+2. Execute the script from your terminal or Git Bash.
+    1. For example, to execute the Python deployment script in a Unix-based system or using Git Bash, run `bash python-app.sh`.
 3. Wait for the CloudFormation stack creation to finish.
     1. Navigate to [CloudFormation console](https://console.aws.amazon.com/cloudformation/home).
     2. Wait for the stack named **sp-api-app-*random_suffix*** to show status `CREATE_COMPLETE`.
@@ -201,8 +203,8 @@ The deployment script creates a number of resources in the AWS cloud which you m
 To clean up these resources, follow the steps below.
 1. Identify the clean-up script for the programming language of the Sample Solution App deployed to the AWS cloud.
     1. For example, for the Python application the file is [app/scripts/python/python-app-clean.sh](app/scripts/python/python-app-clean.sh).
-2. Execute the script from your terminal.
-    1. For example, to execute the Python clean-up script in a Unix-based system, run `bash python-app-clean.sh`.
+2. Execute the script from your terminal or Git Bash.
+    1. For example, to execute the Python clean-up script in a Unix-based system or using Git Bash, run `bash python-app-clean.sh`.
 
 ### 7. Troubleshooting
 If the state machine execution fails, follow the steps below to identify the root-cause and retry the workflow.

--- a/use-cases/data-kiosk/app/scripts/shared/deploy-app.sh
+++ b/use-cases/data-kiosk/app/scripts/shared/deploy-app.sh
@@ -17,7 +17,7 @@ case "${language}" in
 esac
 
 # Verify pre-requisites
-bash ../shared/pre-requisites.sh "$@"
+source ../shared/pre-requisites.sh $language
 if [ $? -ne 0 ]
 then
   echo "Verifying pre-requisites failed"
@@ -101,9 +101,13 @@ if [ "$language" == "python" ]; then
   get_document_handler="src/get_document_handler.lambda_handler"
   store_document_handler="src/store_document_handler.lambda_handler"
 	(
-	  cd "${python_code_folder}" || exit
-	  zip -rq "${python_code_zip}" . -x "target/"
-	)
+    cd "${python_code_folder}" || exit
+    if command -v zip >/dev/null 2>&1; then
+      zip -rq "${python_code_zip}" . -x "target/"
+    elif [[ "$OSTYPE" == "msys"* ]]; then
+      powershell -Command "\$filestoArchive = Get-ChildItem -Path . -Exclude 'target'; Compress-Archive -Path \$filesToArchive -DestinationPath '${python_code_zip}'"
+    fi
+  )
 	AWS_ACCESS_KEY_ID=${access_key} AWS_SECRET_ACCESS_KEY=${secret_key} \
 	  aws s3 cp "${python_code_folder}${python_code_zip}" "s3://${bucket_name}/${code_s3_key}"
 # If it's a Java app, package the code and upload it to S3

--- a/use-cases/data-kiosk/app/scripts/shared/pre-requisites.sh
+++ b/use-cases/data-kiosk/app/scripts/shared/pre-requisites.sh
@@ -1,25 +1,75 @@
 #!/bin/bash
 
-# This functions installs the AWS CLI
-install_aws_cli () {
+# Function to check if AWS CLI is installed
+check_aws_cli() {
+    if command -v aws >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to install AWS CLI on macOS
+install_aws_cli_mac() {
   while true; do
-    read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
-    case "${response}" in
-      [yY][eE][sS]|[yY])
-        echo "Installing the AWS CLI ..."
-        echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
-        curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-        echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
-        echo "You might be requested to enter your password in the next step."
-        sudo installer -pkg AWSCLIV2.pkg -target /
-        break;;
-      [nN][oO]|[nN])
-        echo "The deployment script can't be executed if the AWS CLI is not installed."
-        exit -1;;
-      *) echo "Please answer 'yes' or 'no'";;
-    esac
+      read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+      case "${response}" in
+        [yY][eE][sS]|[yY])
+          echo "Installing the AWS CLI on macOS..."
+          echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
+          curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+          echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
+          echo "You might be requested to enter your password in the next step."
+          sudo installer -pkg AWSCLIV2.pkg -target /
+          echo "The AWS CLI was successfully installed on macOS."
+          break;;
+        [nN][oO]|[nN])
+          echo "The deployment script can't be executed if the AWS CLI is not installed."
+          exit -1;;
+        *) echo "Please answer 'yes' or 'no'";;
+      esac
   done
-  echo "The AWS CLI was successfully installed"
+}
+
+# Function to install AWS CLI on Windows
+install_aws_cli_windows() {
+  while true; do
+        read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+        case "${response}" in
+          [yY][eE][sS]|[yY])
+            echo "Installing the AWS CLI on Windows..."
+            echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.msi."
+            curl "https://awscli.amazonaws.com/AWSCLIV2.msi" -o "AWSCLIV2.msi"
+
+            echo "Executing 'msiexec'. Installation started..."
+            echo "Please wait..."
+            msiexec //i AWSCLIV2.msi //quiet
+
+            # get path to aws cli and add it to current PATH
+            awsDirectory=$(powershell -C "(Get-ChildItem -Path 'C:\Program Files' -Recurse -Include aws.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty DirectoryName -First 1)")
+            awsPosixDirectory=$(echo "/$awsDirectory" | sed 's/\\/\//g' | sed 's/://')
+            export PATH="$PATH:${awsPosixDirectory}"
+
+            echo "The AWS CLI was successfully installed on Windows."
+            echo "Removing the installer..."
+            rm -f AWSCLIV2.msi
+            break;;
+          [nN][oO]|[nN])
+            echo "The deployment script can't be executed if the AWS CLI is not installed."
+            exit -1;;
+          *) echo "Please answer 'yes' or 'no'";;
+        esac
+    done
+}
+
+# Function to check if Maven is installed
+check_maven() {
+    if command -v mvn >/dev/null 2>&1; then
+        return 0
+    else
+        echo "Maven is not installed."
+        return 1
+    fi
 }
 
 add_homebrew_to_shell() {
@@ -27,32 +77,49 @@ add_homebrew_to_shell() {
   eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 }
 
-install_maven () {
-  while true; do
-      read -p "Maven is not installed in the system. Do you wish to install it now? [y/n] " response
-      case "${response}" in
-        [yY][eE][sS]|[yY])
-          echo "Installing Maven ..."
-          # Confirm that Homebrew is installed. Install it otherwise
-          brew --version >/dev/null 2> /dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          if [ -n "$BASH_VERSION" ]; then
-            add_homebrew_to_shell "$HOME/.bashrc"
-            add_homebrew_to_shell "$HOME/.bash_profile"
-          elif [ -n "$ZSH_VERSION" ]; then
-            add_homebrew_to_shell "$HOME/.zshrc"
-            add_homebrew_to_shell "$HOME/.zprofile"
-          else
-            echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
-          fi
-          brew install maven
-          break;;
-        [nN][oO]|[nN])
-          echo "The deployment script can't be executed if Maven is not installed."
-          exit -1;;
-        *) echo "Please answer 'yes' or 'no'";;
-      esac
-    done
-    echo "Maven was successfully installed"
+# Function to install Maven on macOS
+install_maven_mac() {
+    echo "Installing Maven on macOS..."
+    # Confirm that Homebrew is installed. Install it otherwise
+    brew --version >/dev/null 2>/dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    if [ -n "$BASH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.bashrc"
+        add_homebrew_to_shell "$HOME/.bash_profile"
+    elif [ -n "$ZSH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.zshrc"
+        add_homebrew_to_shell "$HOME/.zprofile"
+    else
+        echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
+    fi
+    brew install maven
+    echo "Maven was successfully installed on macOS."
+}
+
+# Function to install Maven on Windows
+install_maven_windows() {
+    echo "Installing Maven on Windows..."
+    MAVEN_FOLDER="apache-maven-3.9.8"
+    MAVEN_FILE_NAME="$MAVEN_FOLDER-bin.zip"
+    MAVEN_VERSION="3.9.8"
+
+    DEFAULT_DRIVE=$(powershell.exe -C "(Get-WmiObject -Class Win32_OperatingSystem).SystemDrive")
+
+    curl "https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/$MAVEN_FILE_NAME" -o "$MAVEN_FILE_NAME"
+    mv "$MAVEN_FILE_NAME" "$DEFAULT_DRIVE\\$MAVEN_FILE_NAME"
+    echo "Extracting the downloaded package..."
+
+    unzip -qq "$DEFAULT_DRIVE/$MAVEN_FILE_NAME" -d "$DEFAULT_DRIVE/"
+    rm -f "$DEFAULT_DRIVE/$MAVEN_FILE_NAME"
+
+    # Append mvn path to System Path
+    appendMavenToPathCommand="\$oldPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine'); [System.Environment]::SetEnvironmentVariable('Path', \$oldPath + ';$DEFAULT_DRIVE/$MAVEN_FOLDER/bin', 'Machine')"
+    powershell.exe -Command "${appendMavenToPathCommand}"
+
+    # refresh current PATH to run mvn
+    export PATH="$PATH:$DEFAULT_DRIVE/$MAVEN_FOLDER/bin"
+
+    mvn --version
+    echo "Maven was successfully installed on Windows."
 }
 
 # Confirm that the user has updated the config file. Stop the execution otherwise
@@ -72,7 +139,20 @@ echo
 
 # Confirm that the AWS CLI is installed. Ask the user for confirmation and install it otherwise
 echo "The AWS CLI is required to deploy the Sample Solution App. Checking if it is installed in the system ..."
-aws --version > /dev/null 2> /dev/null || install_aws_cli
+# Check if AWS CLI is installed
+if check_aws_cli; then
+    echo "AWS CLI is already installed. No action required."
+else
+    # Check the operating system and call the appropriate installation function
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        install_aws_cli_mac
+    elif [[ "$OSTYPE" == "msys" ]]; then
+        install_aws_cli_windows
+    else
+        echo "Unsupported operating system. The script supports macOS and Windows only."
+        exit 1
+    fi
+fi
 
 echo
 
@@ -89,35 +169,62 @@ echo
 # Language-specific pre-requisites
 
 # Get the programming language from the input arguments
-language=""
-while getopts 'l:' flag; do
-  case "${flag}" in
-    l) language="${OPTARG}";;
-  esac
-done
+language=$1
+
+if [ -z "${language}" ]; then
+  echo "A programming language is not selected. Aborting..."
+  exit 1
+fi
 
 # If it's a Java app, confirm that Maven is installed
 if [ "$language" == "java" ]; then
-  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system ..."
-  mvn --version > /dev/null 2> /dev/null || install_maven
+  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system..."
+
+  if check_maven; then
+      echo "Maven is already installed. No action required."
+  else
+      # Check the operating system and call the appropriate installation function
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+          install_maven_mac
+      elif [[ "$OSTYPE" == "msys" ]]; then
+          install_maven_windows
+      else
+          echo "Unsupported operating system. The script supports macOS and Windows only."
+          exit 1
+      fi
+  fi
 fi
 
 # If it's a Python app, confirm that necessary Python packages are installed
 if [ "$language" == "python" ]; then
   echo "Certain Python packages are required to deploy a Python Sample Solution App. Checking if they are installed ..."
-  python3 -c "
-import pkg_resources
-import os
+  pythonCommand="import sys
+import subprocess
+from importlib.metadata import Distribution
 REQUIRED_PACKAGES = ['boto3', 'requests', 'setuptools']
+def install_package(package):
+    try:
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', package])
+        print(f'{package} has been installed successfully.')
+    except subprocess.CalledProcessError as e:
+        print(f'Error installing {package}.')
+
 for package in REQUIRED_PACKAGES:
   try:
-    dist = pkg_resources.get_distribution(package)
-    print('{} ({}) is installed'.format(dist.key, dist.version))
-  except pkg_resources.DistributionNotFound:
-    print('{} is NOT installed'.format(package))
-    print('Installing {} ...'.format(package))
-    os.system('python3 -m pip install {}'.format(package))
-  "
+        dist = Distribution.from_name(package)
+        print(f'{dist.metadata['Name']} ({dist.metadata['Version']}) is installed')
+  except ImportError:
+        print(f'{package} is NOT installed')
+        install_package(package)"
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    python3 -c "$pythonCommand"
+  elif [[ "$OSTYPE" == "msys" ]]; then
+    py -c "$pythonCommand"
+  else
+    echo "Unsupported operating system. The script supports macOS and Windows only."
+    exit 1
+  fi
 fi
 
 # If it's a CSharp app, install Amazon lambda tools or update if already installed

--- a/use-cases/data-kiosk/code/java/pom.xml
+++ b/use-cases/data-kiosk/code/java/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/use-cases/error-monitoring/README.md
+++ b/use-cases/error-monitoring/README.md
@@ -29,6 +29,8 @@ The pre-requisites for deploying the Sample Solution App to the AWS cloud are:
 * [Maven](https://maven.apache.org/)
     * Just for deploying a Java-based application
     * If not present, it will be installed as part of the deployment script
+* [GitBash](https://git-scm.com/download/win)
+    * in case you use Windows in order to run the deployment script.
 
 ## Usage
 ### 1. Update config file
@@ -116,8 +118,8 @@ The deployment script will create a Sample Solution App in the AWS cloud.
 To execute the deployment script, follow the steps below.
 1. Identify the deployment script for the programming language you want for your Sample Solution App.
     1. For example, for the Java application the file is [app/scripts/java/java-app.sh](app/scripts/java/java-app.sh)
-2. Execute the script from your terminal
-    1. For example, to execute the Java deployment script in a Unix-based system, run `bash java-app.sh`
+2. Execute the script from your terminal or Git Bash
+    1. For example, to execute the Java deployment script in a Unix-based system or using Git Bash, run `bash java-app.sh`
 3. Wait for the CloudFormation stack creation to finish
     1. Navigate to [CloudFormation console](https://console.aws.amazon.com/cloudformation/home)
     2. Wait for the stack named **sp-api-app-\<language\>-*random_suffix*** to show status `CREATE_COMPLETE`
@@ -161,8 +163,8 @@ The deployment script creates a number of resources in the AWS cloud which you m
 To clean up these resources, follow the steps below.
 1. Identify the clean-up script for the programming language of the Sample Solution App deployed to the AWS cloud.
     1. For example, for the Java application the file is [app/scripts/java/java-app-clean.sh](app/scripts/java/java-app-clean.sh)
-2. Execute the script from your terminal
-    1. For example, to execute the Java clean-up script in a Unix-based system, run `bash java-app-clean.sh`
+2. Execute the script from your terminal or Git Bash
+    1. For example, to execute the Java clean-up script in a Unix-based system or using Git Bash, run `bash java-app-clean.sh`
 
 ### 6. Troubleshooting
 If you do not receive email notifications, follow the steps below to identify the root-cause and retry the workflow

--- a/use-cases/error-monitoring/app/scripts/shared/pre-requisites.sh
+++ b/use-cases/error-monitoring/app/scripts/shared/pre-requisites.sh
@@ -1,25 +1,75 @@
 #!/bin/bash
 
-# This functions installs the AWS CLI
-install_aws_cli () {
+# Function to check if AWS CLI is installed
+check_aws_cli() {
+    if command -v aws >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to install AWS CLI on macOS
+install_aws_cli_mac() {
   while true; do
-    read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
-    case "${response}" in
-      [yY][eE][sS]|[yY])
-        echo "Installing the AWS CLI ..."
-        echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
-        curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-        echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
-        echo "You might be requested to enter your password in the next step."
-        sudo installer -pkg AWSCLIV2.pkg -target /
-        break;;
-      [nN][oO]|[nN])
-        echo "The deployment script can't be executed if the AWS CLI is not installed."
-        exit -1;;
-      *) echo "Please answer 'yes' or 'no'";;
-    esac
+      read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+      case "${response}" in
+        [yY][eE][sS]|[yY])
+          echo "Installing the AWS CLI on macOS..."
+          echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
+          curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+          echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
+          echo "You might be requested to enter your password in the next step."
+          sudo installer -pkg AWSCLIV2.pkg -target /
+          echo "The AWS CLI was successfully installed on macOS."
+          break;;
+        [nN][oO]|[nN])
+          echo "The deployment script can't be executed if the AWS CLI is not installed."
+          exit -1;;
+        *) echo "Please answer 'yes' or 'no'";;
+      esac
   done
-  echo "The AWS CLI was successfully installed"
+}
+
+# Function to install AWS CLI on Windows
+install_aws_cli_windows() {
+  while true; do
+        read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+        case "${response}" in
+          [yY][eE][sS]|[yY])
+            echo "Installing the AWS CLI on Windows..."
+            echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.msi."
+            curl "https://awscli.amazonaws.com/AWSCLIV2.msi" -o "AWSCLIV2.msi"
+
+            echo "Executing 'msiexec'. Installation started..."
+            echo "Please wait..."
+            msiexec //i AWSCLIV2.msi //quiet
+
+            # get path to aws cli and add it to current PATH
+            awsDirectory=$(powershell -C "(Get-ChildItem -Path 'C:\Program Files' -Recurse -Include aws.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty DirectoryName -First 1)")
+            awsPosixDirectory=$(echo "/$awsDirectory" | sed 's/\\/\//g' | sed 's/://')
+            export PATH="$PATH:${awsPosixDirectory}"
+
+            echo "The AWS CLI was successfully installed on Windows."
+            echo "Removing the installer..."
+            rm -f AWSCLIV2.msi
+            break;;
+          [nN][oO]|[nN])
+            echo "The deployment script can't be executed if the AWS CLI is not installed."
+            exit -1;;
+          *) echo "Please answer 'yes' or 'no'";;
+        esac
+    done
+}
+
+# Function to check if Maven is installed
+check_maven() {
+    if command -v mvn >/dev/null 2>&1; then
+        return 0
+    else
+        echo "Maven is not installed."
+        return 1
+    fi
 }
 
 add_homebrew_to_shell() {
@@ -27,32 +77,49 @@ add_homebrew_to_shell() {
   eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 }
 
-install_maven () {
-  while true; do
-      read -p "Maven is not installed in the system. Do you wish to install it now? [y/n] " response
-      case "${response}" in
-        [yY][eE][sS]|[yY])
-          echo "Installing Maven ..."
-          # Confirm that Homebrew is installed. Install it otherwise
-          brew --version >/dev/null 2> /dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          if [ -n "$BASH_VERSION" ]; then
-            add_homebrew_to_shell "$HOME/.bashrc"
-            add_homebrew_to_shell "$HOME/.bash_profile"
-          elif [ -n "$ZSH_VERSION" ]; then
-            add_homebrew_to_shell "$HOME/.zshrc"
-            add_homebrew_to_shell "$HOME/.zprofile"
-          else
-            echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
-          fi
-          brew install maven
-          break;;
-        [nN][oO]|[nN])
-          echo "The deployment script can't be executed if Maven is not installed."
-          exit -1;;
-        *) echo "Please answer 'yes' or 'no'";;
-      esac
-    done
-    echo "Maven was successfully installed"
+# Function to install Maven on macOS
+install_maven_mac() {
+    echo "Installing Maven on macOS..."
+    # Confirm that Homebrew is installed. Install it otherwise
+    brew --version >/dev/null 2>/dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    if [ -n "$BASH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.bashrc"
+        add_homebrew_to_shell "$HOME/.bash_profile"
+    elif [ -n "$ZSH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.zshrc"
+        add_homebrew_to_shell "$HOME/.zprofile"
+    else
+        echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
+    fi
+    brew install maven
+    echo "Maven was successfully installed on macOS."
+}
+
+# Function to install Maven on Windows
+install_maven_windows() {
+    echo "Installing Maven on Windows..."
+    MAVEN_FOLDER="apache-maven-3.9.8"
+    MAVEN_FILE_NAME="$MAVEN_FOLDER-bin.zip"
+    MAVEN_VERSION="3.9.8"
+
+    DEFAULT_DRIVE=$(powershell.exe -C "(Get-WmiObject -Class Win32_OperatingSystem).SystemDrive")
+
+    curl "https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/$MAVEN_FILE_NAME" -o "$MAVEN_FILE_NAME"
+    mv "$MAVEN_FILE_NAME" "$DEFAULT_DRIVE\\$MAVEN_FILE_NAME"
+    echo "Extracting the downloaded package..."
+
+    unzip -qq "$DEFAULT_DRIVE/$MAVEN_FILE_NAME" -d "$DEFAULT_DRIVE/"
+    rm -f "$DEFAULT_DRIVE/$MAVEN_FILE_NAME"
+
+    # Append mvn path to System Path
+    appendMavenToPathCommand="\$oldPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine'); [System.Environment]::SetEnvironmentVariable('Path', \$oldPath + ';$DEFAULT_DRIVE/$MAVEN_FOLDER/bin', 'Machine')"
+    powershell.exe -Command "${appendMavenToPathCommand}"
+
+    # refresh current PATH to run mvn
+    export PATH="$PATH:$DEFAULT_DRIVE/$MAVEN_FOLDER/bin"
+
+    mvn --version
+    echo "Maven was successfully installed on Windows."
 }
 
 # Confirm that the user has updated the config file. Stop the execution otherwise
@@ -72,7 +139,20 @@ echo
 
 # Confirm that the AWS CLI is installed. Ask the user for confirmation and install it otherwise
 echo "The AWS CLI is required to deploy the Sample Solution App. Checking if it is installed in the system ..."
-aws --version > /dev/null 2> /dev/null || install_aws_cli
+# Check if AWS CLI is installed
+if check_aws_cli; then
+    echo "AWS CLI is already installed. No action required."
+else
+    # Check the operating system and call the appropriate installation function
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        install_aws_cli_mac
+    elif [[ "$OSTYPE" == "msys" ]]; then
+        install_aws_cli_windows
+    else
+        echo "Unsupported operating system. The script supports macOS and Windows only."
+        exit 1
+    fi
+fi
 
 echo
 
@@ -89,35 +169,62 @@ echo
 # Language-specific pre-requisites
 
 # Get the programming language from the input arguments
-language=""
-while getopts 'l:' flag; do
-  case "${flag}" in
-    l) language="${OPTARG}";;
-  esac
-done
+language=$1
+
+if [ -z "${language}" ]; then
+  echo "A programming language is not selected. Aborting..."
+  exit 1
+fi
 
 # If it's a Java app, confirm that Maven is installed
 if [ "$language" == "java" ]; then
-  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system ..."
-  mvn --version > /dev/null 2> /dev/null || install_maven
+  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system..."
+
+  if check_maven; then
+      echo "Maven is already installed. No action required."
+  else
+      # Check the operating system and call the appropriate installation function
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+          install_maven_mac
+      elif [[ "$OSTYPE" == "msys" ]]; then
+          install_maven_windows
+      else
+          echo "Unsupported operating system. The script supports macOS and Windows only."
+          exit 1
+      fi
+  fi
 fi
 
 # If it's a Python app, confirm that necessary Python packages are installed
 if [ "$language" == "python" ]; then
   echo "Certain Python packages are required to deploy a Python Sample Solution App. Checking if they are installed ..."
-  python3 -c "
-import pkg_resources
-import os
+  pythonCommand="import sys
+import subprocess
+from importlib.metadata import Distribution
 REQUIRED_PACKAGES = ['boto3', 'requests', 'setuptools']
+def install_package(package):
+    try:
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', package])
+        print(f'{package} has been installed successfully.')
+    except subprocess.CalledProcessError as e:
+        print(f'Error installing {package}.')
+
 for package in REQUIRED_PACKAGES:
   try:
-    dist = pkg_resources.get_distribution(package)
-    print('{} ({}) is installed'.format(dist.key, dist.version))
-  except pkg_resources.DistributionNotFound:
-    print('{} is NOT installed'.format(package))
-    print('Installing {} ...'.format(package))
-    os.system('python3 -m pip install {}'.format(package))
-  "
+        dist = Distribution.from_name(package)
+        print(f'{dist.metadata['Name']} ({dist.metadata['Version']}) is installed')
+  except ImportError:
+        print(f'{package} is NOT installed')
+        install_package(package)"
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    python3 -c "$pythonCommand"
+  elif [[ "$OSTYPE" == "msys" ]]; then
+    py -c "$pythonCommand"
+  else
+    echo "Unsupported operating system. The script supports macOS and Windows only."
+    exit 1
+  fi
 fi
 
 # If it's a CSharp app, install Amazon lambda tools or update if already installed

--- a/use-cases/error-monitoring/code/java/pom.xml
+++ b/use-cases/error-monitoring/code/java/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/use-cases/fulfillment-outbound/README.md
+++ b/use-cases/fulfillment-outbound/README.md
@@ -47,6 +47,8 @@ The pre-requisites for deploying the Sample Solution App to the AWS cloud are:
 * [Maven](https://maven.apache.org/)
   * Just for deploying a Java-based application
   * If not present, it will be installed as part of the deployment script
+* [GitBash](https://git-scm.com/download/win)
+    * in case you use Windows in order to run the deployment script.
 
 ## Usage
 ### 1. Update config file
@@ -133,8 +135,8 @@ The deployment script will create a Sample Solution App in the AWS cloud.
 To execute the deployment script, follow the steps below.
 1. Identify the deployment script for the programming language you want for your Sample Solution App.
    1. For example, for the Java application the file is [app/scripts/java/java-app.sh](app/scripts/java/java-app.sh)
-2. Execute the script from your terminal
-   1. For example, to execute the Java deployment script in a Unix-based system, run `bash java-app.sh`
+2. Execute the script from your terminal or Git Bash
+   1. For example, to execute the Java deployment script in a Unix-based system or using Git Bash, run `bash java-app.sh`
 3. Wait for the CloudFormation stack creation to finish
    1. Navigate to [CloudFormation console](https://console.aws.amazon.com/cloudformation/home)
    2. Wait for the stack named **sp-api-app-\<language\>-*random_suffix*** to show status `CREATE_COMPLETE` 
@@ -273,8 +275,8 @@ The deployment script creates a number of resources in the AWS cloud which you m
 To clean up these resources, follow the steps below.
 1. Identify the clean-up script for the programming language of the Sample Solution App deployed to the AWS cloud.
    1. For example, for the Java application the file is [app/scripts/java/java-app-clean.sh](app/scripts/java/java-app-clean.sh)
-2. Execute the script from your terminal
-   1. For example, to execute the Java clean-up script in a Unix-based system, run `bash java-app-clean.sh`
+2. Execute the script from your terminal or Git Bash
+   1. For example, to execute the Java clean-up script in a Unix-based system or using Git Bash, run `bash java-app-clean.sh`
    2. Wait for the script to finish
 
 ### 7. Troubleshooting

--- a/use-cases/fulfillment-outbound/app/scripts/shared/deploy-app.sh
+++ b/use-cases/fulfillment-outbound/app/scripts/shared/deploy-app.sh
@@ -16,7 +16,7 @@ case "${language}" in
 esac
 
 # Verify pre-requisites
-bash ../shared/pre-requisites.sh "$@"
+source ../shared/pre-requisites.sh $language
 if [ $? -ne 0 ]
 then
   echo "Verifying pre-requisites failed"

--- a/use-cases/fulfillment-outbound/app/scripts/shared/pre-requisites.sh
+++ b/use-cases/fulfillment-outbound/app/scripts/shared/pre-requisites.sh
@@ -1,44 +1,125 @@
 #!/bin/bash
 
-# This functions installs the AWS CLI
-install_aws_cli () {
-  while true; do
-    read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
-    case "${response}" in
-      [yY][eE][sS]|[yY])
-        echo "Installing the AWS CLI ..."
-        echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
-        curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-        echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
-        echo "You might be requested to enter your password in the next step."
-        sudo installer -pkg AWSCLIV2.pkg -target /
-        break;;
-      [nN][oO]|[nN])
-        echo "The deployment script can't be executed if the AWS CLI is not installed."
-        exit -1;;
-      *) echo "Please answer 'yes' or 'no'";;
-    esac
-  done
-  echo "The AWS CLI was successfully installed"
+# Function to check if AWS CLI is installed
+check_aws_cli() {
+    if command -v aws >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
 }
 
-install_maven () {
+# Function to install AWS CLI on macOS
+install_aws_cli_mac() {
   while true; do
-      read -p "Maven is not installed in the system. Do you wish to install it now? [y/n] " response
+      read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
       case "${response}" in
         [yY][eE][sS]|[yY])
-          echo "Installing Maven ..."
-          # Confirm that Homebrew is installed. Install it otherwise
-          brew --version >/dev/null 2> /dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          brew install maven
+          echo "Installing the AWS CLI on macOS..."
+          echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
+          curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+          echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
+          echo "You might be requested to enter your password in the next step."
+          sudo installer -pkg AWSCLIV2.pkg -target /
+          echo "The AWS CLI was successfully installed on macOS."
           break;;
         [nN][oO]|[nN])
-          echo "The deployment script can't be executed if Maven is not installed."
+          echo "The deployment script can't be executed if the AWS CLI is not installed."
           exit -1;;
         *) echo "Please answer 'yes' or 'no'";;
       esac
+  done
+}
+
+# Function to install AWS CLI on Windows
+install_aws_cli_windows() {
+  while true; do
+        read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+        case "${response}" in
+          [yY][eE][sS]|[yY])
+            echo "Installing the AWS CLI on Windows..."
+            echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.msi."
+            curl "https://awscli.amazonaws.com/AWSCLIV2.msi" -o "AWSCLIV2.msi"
+
+            echo "Executing 'msiexec'. Installation started..."
+            echo "Please wait..."
+            msiexec //i AWSCLIV2.msi //quiet
+
+            # get path to aws cli and add it to current PATH
+            awsDirectory=$(powershell -C "(Get-ChildItem -Path 'C:\Program Files' -Recurse -Include aws.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty DirectoryName -First 1)")
+            awsPosixDirectory=$(echo "/$awsDirectory" | sed 's/\\/\//g' | sed 's/://')
+            export PATH="$PATH:${awsPosixDirectory}"
+
+            echo "The AWS CLI was successfully installed on Windows."
+            echo "Removing the installer..."
+            rm -f AWSCLIV2.msi
+            break;;
+          [nN][oO]|[nN])
+            echo "The deployment script can't be executed if the AWS CLI is not installed."
+            exit -1;;
+          *) echo "Please answer 'yes' or 'no'";;
+        esac
     done
-    echo "Maven was successfully installed"
+}
+
+# Function to check if Maven is installed
+check_maven() {
+    if command -v mvn >/dev/null 2>&1; then
+        return 0
+    else
+        echo "Maven is not installed."
+        return 1
+    fi
+}
+
+add_homebrew_to_shell() {
+  echo 'eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)' >> "$1"
+  eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
+}
+
+# Function to install Maven on macOS
+install_maven_mac() {
+    echo "Installing Maven on macOS..."
+    # Confirm that Homebrew is installed. Install it otherwise
+    brew --version >/dev/null 2>/dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    if [ -n "$BASH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.bashrc"
+        add_homebrew_to_shell "$HOME/.bash_profile"
+    elif [ -n "$ZSH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.zshrc"
+        add_homebrew_to_shell "$HOME/.zprofile"
+    else
+        echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
+    fi
+    brew install maven
+    echo "Maven was successfully installed on macOS."
+}
+
+# Function to install Maven on Windows
+install_maven_windows() {
+    echo "Installing Maven on Windows..."
+    MAVEN_FOLDER="apache-maven-3.9.8"
+    MAVEN_FILE_NAME="$MAVEN_FOLDER-bin.zip"
+    MAVEN_VERSION="3.9.8"
+
+    DEFAULT_DRIVE=$(powershell.exe -C "(Get-WmiObject -Class Win32_OperatingSystem).SystemDrive")
+
+    curl "https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/$MAVEN_FILE_NAME" -o "$MAVEN_FILE_NAME"
+    mv "$MAVEN_FILE_NAME" "$DEFAULT_DRIVE\\$MAVEN_FILE_NAME"
+    echo "Extracting the downloaded package..."
+
+    unzip -qq "$DEFAULT_DRIVE/$MAVEN_FILE_NAME" -d "$DEFAULT_DRIVE/"
+    rm -f "$DEFAULT_DRIVE/$MAVEN_FILE_NAME"
+
+    # Append mvn path to System Path
+    appendMavenToPathCommand="\$oldPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine'); [System.Environment]::SetEnvironmentVariable('Path', \$oldPath + ';$DEFAULT_DRIVE/$MAVEN_FOLDER/bin', 'Machine')"
+    powershell.exe -Command "${appendMavenToPathCommand}"
+
+    # refresh current PATH to run mvn
+    export PATH="$PATH:$DEFAULT_DRIVE/$MAVEN_FOLDER/bin"
+
+    mvn --version
+    echo "Maven was successfully installed on Windows."
 }
 
 # Confirm that the user has updated the config file. Stop the execution otherwise
@@ -58,7 +139,20 @@ echo
 
 # Confirm that the AWS CLI is installed. Ask the user for confirmation and install it otherwise
 echo "The AWS CLI is required to deploy the Sample Solution App. Checking if it is installed in the system ..."
-aws --version > /dev/null 2> /dev/null || install_aws_cli
+# Check if AWS CLI is installed
+if check_aws_cli; then
+    echo "AWS CLI is already installed. No action required."
+else
+    # Check the operating system and call the appropriate installation function
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        install_aws_cli_mac
+    elif [[ "$OSTYPE" == "msys" ]]; then
+        install_aws_cli_windows
+    else
+        echo "Unsupported operating system. The script supports macOS and Windows only."
+        exit 1
+    fi
+fi
 
 echo
 
@@ -75,15 +169,28 @@ echo
 # Language-specific pre-requisites
 
 # Get the programming language from the input arguments
-language=""
-while getopts 'l:' flag; do
-  case "${flag}" in
-    l) language="${OPTARG}";;
-  esac
-done
+language=$1
+
+if [ -z "${language}" ]; then
+  echo "A programming language is not selected. Aborting..."
+  exit 1
+fi
 
 # If it's a Java app, confirm that Maven is installed
 if [ "$language" == "java" ]; then
-  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system ..."
-  mvn --version > /dev/null 2> /dev/null || install_maven
+  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system..."
+
+  if check_maven; then
+      echo "Maven is already installed. No action required."
+  else
+      # Check the operating system and call the appropriate installation function
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+          install_maven_mac
+      elif [[ "$OSTYPE" == "msys" ]]; then
+          install_maven_windows
+      else
+          echo "Unsupported operating system. The script supports macOS and Windows only."
+          exit 1
+      fi
+  fi
 fi

--- a/use-cases/fulfillment-outbound/code/java/pom.xml
+++ b/use-cases/fulfillment-outbound/code/java/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/use-cases/fulfillment-outbound/code/java/src/main/java/lambda/utils/ApiUtils.java
+++ b/use-cases/fulfillment-outbound/code/java/src/main/java/lambda/utils/ApiUtils.java
@@ -63,7 +63,7 @@ public class ApiUtils {
 
         NotificationsApi notificationsApi = new NotificationsApi.Builder()
                 .lwaAuthorizationCredentials(lwaAuthorizationCredentials)
-                .endpoint(spApiEndpoint)
+                .endpoint(regionConfig.getSpApiEndpoint())
                 .build();
         setUserAgent(notificationsApi.getApiClient());
 

--- a/use-cases/lwa-rotation/README.md
+++ b/use-cases/lwa-rotation/README.md
@@ -30,6 +30,8 @@ The pre-requisites for deploying the Sample Solution App to the AWS cloud are:
 * [Maven](https://maven.apache.org/)
   * Just for deploying a Java-based application
   * If not present, it will be installed as part of the deployment script
+* [GitBash](https://git-scm.com/download/win)
+    * in case you use Windows in order to run the deployment script.
 
 ## Usage
 ### 1. Update config file
@@ -115,8 +117,8 @@ The deployment script will create a Sample Solution App in the AWS cloud.
 To execute the deployment script, follow the steps below.
 1. Identify the deployment script for the programming language you want for your Sample Solution App.
    1. For example, for the Java application the file is [app/scripts/java/java-app.sh](app/scripts/java/java-app.sh)
-2. Execute the script from your terminal
-   1. For example, to execute the Java deployment script in a Unix-based system, run `bash java-app.sh`
+2. Execute the script from your terminal or Git Bash
+   1. For example, to execute the Java deployment script in a Unix-based system or using Git Bash, run `bash java-app.sh`
 
 ### 4. Test the sample solution
 The deployment script creates a Sample Solution App in the AWS cloud. The solution consists of AWS SQS queues to receive the LWA secret expiry notification and LWA new secret notification. These notifications will trigger the respective Lambda functions to rotate the LWA secrets and update the LWA secrets in the AWS Secrets Manager.
@@ -205,8 +207,8 @@ The deployment script creates a number of resources in the AWS cloud which you m
 To clean up these resources, follow the steps below.
 1. Identify the clean-up script for the programming language of the Sample Solution App deployed to the AWS cloud.
     1. For example, for the Java application the file is [app/scripts/java/java-app-clean.sh](app/scripts/java/java-app-clean.sh)
-2. Execute the script from your terminal
-    1. For example, to execute the Java clean-up script in a Unix-based system, run `bash java-app-clean.sh`
+2. Execute the script from your terminal or Git Bash
+    1. For example, to execute the Java clean-up script in a Unix-based system or using Git Bash, run `bash java-app-clean.sh`
 
 ### 6. Troubleshooting
 If the Lambda Handler fails, follow the steps below to identify the root-cause and retry the workflow

--- a/use-cases/lwa-rotation/app/scripts/shared/deploy-app.sh
+++ b/use-cases/lwa-rotation/app/scripts/shared/deploy-app.sh
@@ -16,7 +16,7 @@ case "${language}" in
 esac
 
 # Verify pre-requisites
-bash ../shared/pre-requisites.sh "$@"
+source ../shared/pre-requisites.sh $language
 if [ $? -ne 0 ]
 then
   echo "Verifying pre-requisites failed"

--- a/use-cases/lwa-rotation/app/scripts/shared/pre-requisites.sh
+++ b/use-cases/lwa-rotation/app/scripts/shared/pre-requisites.sh
@@ -1,25 +1,75 @@
 #!/bin/bash
 
-# This functions installs the AWS CLI
-install_aws_cli () {
+# Function to check if AWS CLI is installed
+check_aws_cli() {
+    if command -v aws >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to install AWS CLI on macOS
+install_aws_cli_mac() {
   while true; do
-    read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
-    case "${response}" in
-      [yY][eE][sS]|[yY])
-        echo "Installing the AWS CLI ..."
-        echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
-        curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-        echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
-        echo "You might be requested to enter your password in the next step."
-        sudo installer -pkg AWSCLIV2.pkg -target /
-        break;;
-      [nN][oO]|[nN])
-        echo "The deployment script can't be executed if the AWS CLI is not installed."
-        exit -1;;
-      *) echo "Please answer 'yes' or 'no'";;
-    esac
+      read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+      case "${response}" in
+        [yY][eE][sS]|[yY])
+          echo "Installing the AWS CLI on macOS..."
+          echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
+          curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+          echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
+          echo "You might be requested to enter your password in the next step."
+          sudo installer -pkg AWSCLIV2.pkg -target /
+          echo "The AWS CLI was successfully installed on macOS."
+          break;;
+        [nN][oO]|[nN])
+          echo "The deployment script can't be executed if the AWS CLI is not installed."
+          exit -1;;
+        *) echo "Please answer 'yes' or 'no'";;
+      esac
   done
-  echo "The AWS CLI was successfully installed"
+}
+
+# Function to install AWS CLI on Windows
+install_aws_cli_windows() {
+  while true; do
+        read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+        case "${response}" in
+          [yY][eE][sS]|[yY])
+            echo "Installing the AWS CLI on Windows..."
+            echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.msi."
+            curl "https://awscli.amazonaws.com/AWSCLIV2.msi" -o "AWSCLIV2.msi"
+
+            echo "Executing 'msiexec'. Installation started..."
+            echo "Please wait..."
+            msiexec //i AWSCLIV2.msi //quiet
+
+            # get path to aws cli and add it to current PATH
+            awsDirectory=$(powershell -C "(Get-ChildItem -Path 'C:\Program Files' -Recurse -Include aws.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty DirectoryName -First 1)")
+            awsPosixDirectory=$(echo "/$awsDirectory" | sed 's/\\/\//g' | sed 's/://')
+            export PATH="$PATH:${awsPosixDirectory}"
+
+            echo "The AWS CLI was successfully installed on Windows."
+            echo "Removing the installer..."
+            rm -f AWSCLIV2.msi
+            break;;
+          [nN][oO]|[nN])
+            echo "The deployment script can't be executed if the AWS CLI is not installed."
+            exit -1;;
+          *) echo "Please answer 'yes' or 'no'";;
+        esac
+    done
+}
+
+# Function to check if Maven is installed
+check_maven() {
+    if command -v mvn >/dev/null 2>&1; then
+        return 0
+    else
+        echo "Maven is not installed."
+        return 1
+    fi
 }
 
 add_homebrew_to_shell() {
@@ -27,32 +77,49 @@ add_homebrew_to_shell() {
   eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 }
 
-install_maven () {
-  while true; do
-      read -p "Maven is not installed in the system. Do you wish to install it now? [y/n] " response
-      case "${response}" in
-        [yY][eE][sS]|[yY])
-          echo "Installing Maven ..."
-          # Confirm that Homebrew is installed. Install it otherwise
-          brew --version >/dev/null 2> /dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          if [ -n "$BASH_VERSION" ]; then
-            add_homebrew_to_shell "$HOME/.bashrc"
-            add_homebrew_to_shell "$HOME/.bash_profile"
-          elif [ -n "$ZSH_VERSION" ]; then
-            add_homebrew_to_shell "$HOME/.zshrc"
-            add_homebrew_to_shell "$HOME/.zprofile"
-          else
-            echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
-          fi
-          brew install maven
-          break;;
-        [nN][oO]|[nN])
-          echo "The deployment script can't be executed if Maven is not installed."
-          exit -1;;
-        *) echo "Please answer 'yes' or 'no'";;
-      esac
-    done
-    echo "Maven was successfully installed"
+# Function to install Maven on macOS
+install_maven_mac() {
+    echo "Installing Maven on macOS..."
+    # Confirm that Homebrew is installed. Install it otherwise
+    brew --version >/dev/null 2>/dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    if [ -n "$BASH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.bashrc"
+        add_homebrew_to_shell "$HOME/.bash_profile"
+    elif [ -n "$ZSH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.zshrc"
+        add_homebrew_to_shell "$HOME/.zprofile"
+    else
+        echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
+    fi
+    brew install maven
+    echo "Maven was successfully installed on macOS."
+}
+
+# Function to install Maven on Windows
+install_maven_windows() {
+    echo "Installing Maven on Windows..."
+    MAVEN_FOLDER="apache-maven-3.9.8"
+    MAVEN_FILE_NAME="$MAVEN_FOLDER-bin.zip"
+    MAVEN_VERSION="3.9.8"
+
+    DEFAULT_DRIVE=$(powershell.exe -C "(Get-WmiObject -Class Win32_OperatingSystem).SystemDrive")
+
+    curl "https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/$MAVEN_FILE_NAME" -o "$MAVEN_FILE_NAME"
+    mv "$MAVEN_FILE_NAME" "$DEFAULT_DRIVE\\$MAVEN_FILE_NAME"
+    echo "Extracting the downloaded package..."
+
+    unzip -qq "$DEFAULT_DRIVE/$MAVEN_FILE_NAME" -d "$DEFAULT_DRIVE/"
+    rm -f "$DEFAULT_DRIVE/$MAVEN_FILE_NAME"
+
+    # Append mvn path to System Path
+    appendMavenToPathCommand="\$oldPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine'); [System.Environment]::SetEnvironmentVariable('Path', \$oldPath + ';$DEFAULT_DRIVE/$MAVEN_FOLDER/bin', 'Machine')"
+    powershell.exe -Command "${appendMavenToPathCommand}"
+
+    # refresh current PATH to run mvn
+    export PATH="$PATH:$DEFAULT_DRIVE/$MAVEN_FOLDER/bin"
+
+    mvn --version
+    echo "Maven was successfully installed on Windows."
 }
 
 # Confirm that the user has updated the config file. Stop the execution otherwise
@@ -72,7 +139,20 @@ echo
 
 # Confirm that the AWS CLI is installed. Ask the user for confirmation and install it otherwise
 echo "The AWS CLI is required to deploy the Sample Solution App. Checking if it is installed in the system ..."
-aws --version > /dev/null 2> /dev/null || install_aws_cli
+# Check if AWS CLI is installed
+if check_aws_cli; then
+    echo "AWS CLI is already installed. No action required."
+else
+    # Check the operating system and call the appropriate installation function
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        install_aws_cli_mac
+    elif [[ "$OSTYPE" == "msys" ]]; then
+        install_aws_cli_windows
+    else
+        echo "Unsupported operating system. The script supports macOS and Windows only."
+        exit 1
+    fi
+fi
 
 echo
 
@@ -89,35 +169,62 @@ echo
 # Language-specific pre-requisites
 
 # Get the programming language from the input arguments
-language=""
-while getopts 'l:' flag; do
-  case "${flag}" in
-    l) language="${OPTARG}";;
-  esac
-done
+language=$1
+
+if [ -z "${language}" ]; then
+  echo "A programming language is not selected. Aborting..."
+  exit 1
+fi
 
 # If it's a Java app, confirm that Maven is installed
 if [ "$language" == "java" ]; then
-  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system ..."
-  mvn --version > /dev/null 2> /dev/null || install_maven
+  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system..."
+
+  if check_maven; then
+      echo "Maven is already installed. No action required."
+  else
+      # Check the operating system and call the appropriate installation function
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+          install_maven_mac
+      elif [[ "$OSTYPE" == "msys" ]]; then
+          install_maven_windows
+      else
+          echo "Unsupported operating system. The script supports macOS and Windows only."
+          exit 1
+      fi
+  fi
 fi
 
 # If it's a Python app, confirm that necessary Python packages are installed
 if [ "$language" == "python" ]; then
   echo "Certain Python packages are required to deploy a Python Sample Solution App. Checking if they are installed ..."
-  python3 -c "
-import pkg_resources
-import os
+  pythonCommand="import sys
+import subprocess
+from importlib.metadata import Distribution
 REQUIRED_PACKAGES = ['boto3', 'requests', 'setuptools']
+def install_package(package):
+    try:
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', package])
+        print(f'{package} has been installed successfully.')
+    except subprocess.CalledProcessError as e:
+        print(f'Error installing {package}.')
+
 for package in REQUIRED_PACKAGES:
   try:
-    dist = pkg_resources.get_distribution(package)
-    print('{} ({}) is installed'.format(dist.key, dist.version))
-  except pkg_resources.DistributionNotFound:
-    print('{} is NOT installed'.format(package))
-    print('Installing {} ...'.format(package))
-    os.system('python3 -m pip install {}'.format(package))
-  "
+        dist = Distribution.from_name(package)
+        print(f'{dist.metadata['Name']} ({dist.metadata['Version']}) is installed')
+  except ImportError:
+        print(f'{package} is NOT installed')
+        install_package(package)"
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    python3 -c "$pythonCommand"
+  elif [[ "$OSTYPE" == "msys" ]]; then
+    py -c "$pythonCommand"
+  else
+    echo "Unsupported operating system. The script supports macOS and Windows only."
+    exit 1
+  fi
 fi
 
 # If it's a CSharp app, install Amazon lambda tools or update if already installed

--- a/use-cases/lwa-rotation/code/java/pom.xml
+++ b/use-cases/lwa-rotation/code/java/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/use-cases/merchant-fulfillment/README.md
+++ b/use-cases/merchant-fulfillment/README.md
@@ -34,6 +34,8 @@ The pre-requisites for deploying the Sample Solution App to the AWS cloud are:
 * [Maven](https://maven.apache.org/)
   * Just for deploying a Java-based application
   * If not present, it will be installed as part of the deployment script
+* [GitBash](https://git-scm.com/download/win)
+   * in case you use Windows in order to run the deployment script.
 
 ## Usage
 ### 1. Update config file
@@ -122,8 +124,8 @@ The deployment script will create a Sample Solution App in the AWS cloud.
 To execute the deployment script, follow the steps below.
 1. Identify the deployment script for the programming language you want for your Sample Solution App.
    1. For example, for the Java application the file is [app/scripts/java/java-app.sh](app/scripts/java/java-app.sh)
-2. Execute the script from your terminal
-   1. For example, to execute the Java deployment script in a Unix-based system, run `bash java-app.sh`
+2. Execute the script from your terminal or Git Bash
+   1. For example, to execute the Java deployment script in a Unix-based system or using Git Bash, run `bash java-app.sh`
 3. Wait for the CloudFormation stack creation to finish
    1. Navigate to [CloudFormation console](https://console.aws.amazon.com/cloudformation/home)
    2. Wait for the stack named **sp-api-app-\<language\>-*random_suffix*** to show status `CREATE_COMPLETE` 
@@ -195,8 +197,8 @@ The deployment script creates a number of resources in the AWS cloud which you m
 To clean up these resources, follow the steps below.
 1. Identify the clean-up script for the programming language of the Sample Solution App deployed to the AWS cloud.
    1. For example, for the Java application the file is [app/scripts/java/java-app-clean.sh](app/scripts/java/java-app-clean.sh)
-2. Execute the script from your terminal
-   1. For example, to execute the Java clean-up script in a Unix-based system, run `bash java-app-clean.sh`
+2. Execute the script from your terminal or Git Bash
+   1. For example, to execute the Java clean-up script in a Unix-based system or using Git Bash, run `bash java-app-clean.sh`
    2. Wait for the script to finish
 
 ### 7. Troubleshooting

--- a/use-cases/merchant-fulfillment/app/scripts/shared/deploy-app.sh
+++ b/use-cases/merchant-fulfillment/app/scripts/shared/deploy-app.sh
@@ -17,7 +17,7 @@ case "${language}" in
 esac
 
 # Verify pre-requisites
-bash ../shared/pre-requisites.sh "$@"
+source ../shared/pre-requisites.sh $language
 if [ $? -ne 0 ]
 then
   echo "Verifying pre-requisites failed"
@@ -124,9 +124,13 @@ elif [ "$language" == "python" ]; then
   subscribe_notifications_handler="src/subscribe_notifications_handler.lambda_handler"
 
 	(
-	  cd "${python_code_folder}" || exit
-	  zip -rq "${python_code_zip}" . -x "target/"
-	)
+    cd "${python_code_folder}" || exit
+    if command -v zip >/dev/null 2>&1; then
+      zip -rq "${python_code_zip}" . -x "target/"
+    elif [[ "$OSTYPE" == "msys"* ]]; then
+      powershell -Command "\$filestoArchive = Get-ChildItem -Path . -Exclude 'target'; Compress-Archive -Path \$filesToArchive -DestinationPath '${python_code_zip}'"
+    fi
+  )
 	AWS_ACCESS_KEY_ID=${access_key} AWS_SECRET_ACCESS_KEY=${secret_key} \
 	  aws s3 cp "${python_code_folder}${python_code_zip}" "s3://${bucket_name}/${code_s3_key}"
 fi

--- a/use-cases/merchant-fulfillment/app/scripts/shared/pre-requisites.sh
+++ b/use-cases/merchant-fulfillment/app/scripts/shared/pre-requisites.sh
@@ -1,44 +1,125 @@
 #!/bin/bash
 
-# This functions installs the AWS CLI
-install_aws_cli () {
-  while true; do
-    read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
-    case "${response}" in
-      [yY][eE][sS]|[yY])
-        echo "Installing the AWS CLI ..."
-        echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
-        curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-        echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
-        echo "You might be requested to enter your password in the next step."
-        sudo installer -pkg AWSCLIV2.pkg -target /
-        break;;
-      [nN][oO]|[nN])
-        echo "The deployment script can't be executed if the AWS CLI is not installed."
-        exit -1;;
-      *) echo "Please answer 'yes' or 'no'";;
-    esac
-  done
-  echo "The AWS CLI was successfully installed"
+# Function to check if AWS CLI is installed
+check_aws_cli() {
+    if command -v aws >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
 }
 
-install_maven () {
+# Function to install AWS CLI on macOS
+install_aws_cli_mac() {
   while true; do
-      read -p "Maven is not installed in the system. Do you wish to install it now? [y/n] " response
+      read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
       case "${response}" in
         [yY][eE][sS]|[yY])
-          echo "Installing Maven ..."
-          # Confirm that Homebrew is installed. Install it otherwise
-          brew --version >/dev/null 2> /dev/null || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          brew install maven
+          echo "Installing the AWS CLI on macOS..."
+          echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
+          curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+          echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
+          echo "You might be requested to enter your password in the next step."
+          sudo installer -pkg AWSCLIV2.pkg -target /
+          echo "The AWS CLI was successfully installed on macOS."
           break;;
         [nN][oO]|[nN])
-          echo "The deployment script can't be executed if Maven is not installed."
+          echo "The deployment script can't be executed if the AWS CLI is not installed."
           exit -1;;
         *) echo "Please answer 'yes' or 'no'";;
       esac
+  done
+}
+
+# Function to install AWS CLI on Windows
+install_aws_cli_windows() {
+  while true; do
+        read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+        case "${response}" in
+          [yY][eE][sS]|[yY])
+            echo "Installing the AWS CLI on Windows..."
+            echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.msi."
+            curl "https://awscli.amazonaws.com/AWSCLIV2.msi" -o "AWSCLIV2.msi"
+
+            echo "Executing 'msiexec'. Installation started..."
+            echo "Please wait..."
+            msiexec //i AWSCLIV2.msi //quiet
+
+            # get path to aws cli and add it to current PATH
+            awsDirectory=$(powershell -C "(Get-ChildItem -Path 'C:\Program Files' -Recurse -Include aws.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty DirectoryName -First 1)")
+            awsPosixDirectory=$(echo "/$awsDirectory" | sed 's/\\/\//g' | sed 's/://')
+            export PATH="$PATH:${awsPosixDirectory}"
+
+            echo "The AWS CLI was successfully installed on Windows."
+            echo "Removing the installer..."
+            rm -f AWSCLIV2.msi
+            break;;
+          [nN][oO]|[nN])
+            echo "The deployment script can't be executed if the AWS CLI is not installed."
+            exit -1;;
+          *) echo "Please answer 'yes' or 'no'";;
+        esac
     done
-    echo "Maven was successfully installed"
+}
+
+# Function to check if Maven is installed
+check_maven() {
+    if command -v mvn >/dev/null 2>&1; then
+        return 0
+    else
+        echo "Maven is not installed."
+        return 1
+    fi
+}
+
+add_homebrew_to_shell() {
+  echo 'eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)' >> "$1"
+  eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
+}
+
+# Function to install Maven on macOS
+install_maven_mac() {
+    echo "Installing Maven on macOS..."
+    # Confirm that Homebrew is installed. Install it otherwise
+    brew --version >/dev/null 2>/dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    if [ -n "$BASH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.bashrc"
+        add_homebrew_to_shell "$HOME/.bash_profile"
+    elif [ -n "$ZSH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.zshrc"
+        add_homebrew_to_shell "$HOME/.zprofile"
+    else
+        echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
+    fi
+    brew install maven
+    echo "Maven was successfully installed on macOS."
+}
+
+# Function to install Maven on Windows
+install_maven_windows() {
+    echo "Installing Maven on Windows..."
+    MAVEN_FOLDER="apache-maven-3.9.8"
+    MAVEN_FILE_NAME="$MAVEN_FOLDER-bin.zip"
+    MAVEN_VERSION="3.9.8"
+
+    DEFAULT_DRIVE=$(powershell.exe -C "(Get-WmiObject -Class Win32_OperatingSystem).SystemDrive")
+
+    curl "https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/$MAVEN_FILE_NAME" -o "$MAVEN_FILE_NAME"
+    mv "$MAVEN_FILE_NAME" "$DEFAULT_DRIVE\\$MAVEN_FILE_NAME"
+    echo "Extracting the downloaded package..."
+
+    unzip -qq "$DEFAULT_DRIVE/$MAVEN_FILE_NAME" -d "$DEFAULT_DRIVE/"
+    rm -f "$DEFAULT_DRIVE/$MAVEN_FILE_NAME"
+
+    # Append mvn path to System Path
+    appendMavenToPathCommand="\$oldPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine'); [System.Environment]::SetEnvironmentVariable('Path', \$oldPath + ';$DEFAULT_DRIVE/$MAVEN_FOLDER/bin', 'Machine')"
+    powershell.exe -Command "${appendMavenToPathCommand}"
+
+    # refresh current PATH to run mvn
+    export PATH="$PATH:$DEFAULT_DRIVE/$MAVEN_FOLDER/bin"
+
+    mvn --version
+    echo "Maven was successfully installed on Windows."
 }
 
 # Confirm that the user has updated the config file. Stop the execution otherwise
@@ -58,7 +139,20 @@ echo
 
 # Confirm that the AWS CLI is installed. Ask the user for confirmation and install it otherwise
 echo "The AWS CLI is required to deploy the Sample Solution App. Checking if it is installed in the system ..."
-aws --version > /dev/null 2> /dev/null || install_aws_cli
+# Check if AWS CLI is installed
+if check_aws_cli; then
+    echo "AWS CLI is already installed. No action required."
+else
+    # Check the operating system and call the appropriate installation function
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        install_aws_cli_mac
+    elif [[ "$OSTYPE" == "msys" ]]; then
+        install_aws_cli_windows
+    else
+        echo "Unsupported operating system. The script supports macOS and Windows only."
+        exit 1
+    fi
+fi
 
 echo
 
@@ -75,33 +169,66 @@ echo
 # Language-specific pre-requisites
 
 # Get the programming language from the input arguments
-language=""
-while getopts 'l:' flag; do
-  case "${flag}" in
-    l) language="${OPTARG}";;
-  esac
-done
+language=$1
+
+if [ -z "${language}" ]; then
+  echo "A programming language is not selected. Aborting..."
+  exit 1
+fi
 
 # If it's a Java app, confirm that Maven is installed
 if [ "$language" == "java" ]; then
-  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system ..."
-  mvn --version > /dev/null 2> /dev/null || install_maven
+  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system..."
+
+  if check_maven; then
+      echo "Maven is already installed. No action required."
+  else
+      # Check the operating system and call the appropriate installation function
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+          install_maven_mac
+      elif [[ "$OSTYPE" == "msys" ]]; then
+          install_maven_windows
+      else
+          echo "Unsupported operating system. The script supports macOS and Windows only."
+          exit 1
+      fi
+  fi
 fi
 
 # If it's a Python app, confirm that necessary Python packages are installed
 if [ "$language" == "python" ]; then
-	echo "Certain Python packages are required to deploy a Python Sample Solution App. Checking if they are installed ..."
-	python3 -c "
-import pkg_resources
-import os
+  echo "Certain Python packages are required to deploy a Python Sample Solution App. Checking if they are installed ..."
+  pythonCommand="import sys
+import subprocess
+from importlib.metadata import Distribution
 REQUIRED_PACKAGES = ['boto3', 'requests', 'setuptools', 'stringcase']
+def install_package(package):
+    try:
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', package])
+        print(f'{package} has been installed successfully.')
+    except subprocess.CalledProcessError as e:
+        print(f'Error installing {package}.')
+
 for package in REQUIRED_PACKAGES:
-	try:
-	  dist = pkg_resources.get_distribution(package)
-	  print('{} ({}) is installed'.format(dist.key, dist.version))
-	except pkg_resources.DistributionNotFound:
-	  print('{} is NOT installed'.format(package))
-	  print('Installing {} ...'.format(package))
-	  os.system('python3 -m pip install {}'.format(package))
-	"
+  try:
+      dist = Distribution.from_name(package)
+      print(f'{dist.metadata['Name']} ({dist.metadata['Version']}) is installed')
+  except ImportError:
+      print(f'{package} is NOT installed')
+      install_package(package)"
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    python3 -c "$pythonCommand"
+  elif [[ "$OSTYPE" == "msys" ]]; then
+    py -c "$pythonCommand"
+  else
+    echo "Unsupported operating system. The script supports macOS and Windows only."
+    exit 1
+  fi
+fi
+
+# If it's a CSharp app, install Amazon lambda tools or update if already installed
+if [ "$language" == "csharp" ]; then
+echo "Certain Dotnet packages are required to deploy a Csharp Sample Solution App. Checking if they are installed ..."
+dotnet tool install -g Amazon.Lambda.Tools || dotnet tool update -g Amazon.Lambda.Tools
 fi

--- a/use-cases/merchant-fulfillment/code/java/pom.xml
+++ b/use-cases/merchant-fulfillment/code/java/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/use-cases/pricing-b2b/README.md
+++ b/use-cases/pricing-b2b/README.md
@@ -32,6 +32,8 @@ The pre-requisites for deploying the Sample Solution App to the AWS cloud are:
    * If you don't have one, you can create it following the steps  under **Usage - 2. Configure Sample Solution App's IAM user**
 * The [AWS CLI](https://aws.amazon.com/cli/)
    * If not present, it will be installed as part of the deployment script
+* [GitBash](https://git-scm.com/download/win)
+   * in case you use Windows in order to run the deployment script.
 
 ## Usage
 ### 1. Update config file
@@ -80,8 +82,8 @@ The deployment script will create a Sample Solution App in the AWS cloud.
 To execute the deployment script, follow the steps below.
 1. Identify the deployment script for the programming language you want for your Sample Solution App.
    1. For example, for the java application the file is [app/scripts/java/java-app.sh](app/scripts/java/java-app.sh)
-2. Execute the script from your terminal
-   1. For example, to execute the Java deployment script in a Unix-based system, run `bash java-app.sh`
+2. Execute the script from your terminal or Git Bash
+   1. For example, to execute the Java deployment script in a Unix-based system or using Git Bash, run `bash java-app.sh`
 3. Wait for the CloudFormation stack creation to finish
    1. Navigate to [CloudFormation console](https://console.aws.amazon.com/cloudformation/home)
    2. Wait for the stack named **sp-api-app-\<language\>-*random_suffix*** to show status `CREATE_COMPLETE`
@@ -259,8 +261,8 @@ The deployment script creates a number of resources in the AWS cloud which you m
 To clean up these resources, follow the steps below.
 1. Identify the clean-up script for the programming language of the Sample Solution App deployed to the AWS cloud.
    1. For example, for the Java application the file is [app/scripts/java/java-app-clean.sh](app/scripts/java/java-app-clean.sh)
-2. Execute the script from your terminal
-   1. For example, to execute the Java clean-up script in a Unix-based system, run `bash java-app-clean.sh`
+2. Execute the script from your terminal or Git Bash
+   1. For example, to execute the Java clean-up script in a Unix-based system or using Git Bash, run `bash java-app-clean.sh`
 
 ### 7. Troubleshooting
 If the state machine execution fails, follow the steps below to identify the root-cause and retry the workflow

--- a/use-cases/pricing-b2b/app/scripts/shared/pre-requisites.sh
+++ b/use-cases/pricing-b2b/app/scripts/shared/pre-requisites.sh
@@ -1,25 +1,75 @@
 #!/bin/bash
 
-# This functions installs the AWS CLI
-install_aws_cli () {
+# Function to check if AWS CLI is installed
+check_aws_cli() {
+    if command -v aws >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to install AWS CLI on macOS
+install_aws_cli_mac() {
   while true; do
-    read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
-    case "${response}" in
-      [yY][eE][sS]|[yY])
-        echo "Installing the AWS CLI ..."
-        echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
-        curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-        echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
-        echo "You might be requested to enter your password in the next step."
-        sudo installer -pkg AWSCLIV2.pkg -target /
-        break;;
-      [nN][oO]|[nN])
-        echo "The deployment script can't be executed if the AWS CLI is not installed."
-        exit -1;;
-      *) echo "Please answer 'yes' or 'no'";;
-    esac
+      read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+      case "${response}" in
+        [yY][eE][sS]|[yY])
+          echo "Installing the AWS CLI on macOS..."
+          echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
+          curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+          echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
+          echo "You might be requested to enter your password in the next step."
+          sudo installer -pkg AWSCLIV2.pkg -target /
+          echo "The AWS CLI was successfully installed on macOS."
+          break;;
+        [nN][oO]|[nN])
+          echo "The deployment script can't be executed if the AWS CLI is not installed."
+          exit -1;;
+        *) echo "Please answer 'yes' or 'no'";;
+      esac
   done
-  echo "The AWS CLI was successfully installed"
+}
+
+# Function to install AWS CLI on Windows
+install_aws_cli_windows() {
+  while true; do
+        read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+        case "${response}" in
+          [yY][eE][sS]|[yY])
+            echo "Installing the AWS CLI on Windows..."
+            echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.msi."
+            curl "https://awscli.amazonaws.com/AWSCLIV2.msi" -o "AWSCLIV2.msi"
+
+            echo "Executing 'msiexec'. Installation started..."
+            echo "Please wait..."
+            msiexec //i AWSCLIV2.msi //quiet
+
+            # get path to aws cli and add it to current PATH
+            awsDirectory=$(powershell -C "(Get-ChildItem -Path 'C:\Program Files' -Recurse -Include aws.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty DirectoryName -First 1)")
+            awsPosixDirectory=$(echo "/$awsDirectory" | sed 's/\\/\//g' | sed 's/://')
+            export PATH="$PATH:${awsPosixDirectory}"
+
+            echo "The AWS CLI was successfully installed on Windows."
+            echo "Removing the installer..."
+            rm -f AWSCLIV2.msi
+            break;;
+          [nN][oO]|[nN])
+            echo "The deployment script can't be executed if the AWS CLI is not installed."
+            exit -1;;
+          *) echo "Please answer 'yes' or 'no'";;
+        esac
+    done
+}
+
+# Function to check if Maven is installed
+check_maven() {
+    if command -v mvn >/dev/null 2>&1; then
+        return 0
+    else
+        echo "Maven is not installed."
+        return 1
+    fi
 }
 
 add_homebrew_to_shell() {
@@ -27,32 +77,49 @@ add_homebrew_to_shell() {
   eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 }
 
-install_maven () {
-  while true; do
-      read -p "Maven is not installed in the system. Do you wish to install it now? [y/n] " response
-      case "${response}" in
-        [yY][eE][sS]|[yY])
-          echo "Installing Maven ..."
-          # Confirm that Homebrew is installed. Install it otherwise
-          brew --version >/dev/null 2> /dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          if [ -n "$BASH_VERSION" ]; then
-            add_homebrew_to_shell "$HOME/.bashrc"
-            add_homebrew_to_shell "$HOME/.bash_profile"
-          elif [ -n "$ZSH_VERSION" ]; then
-            add_homebrew_to_shell "$HOME/.zshrc"
-            add_homebrew_to_shell "$HOME/.zprofile"
-          else
-            echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
-          fi
-          brew install maven
-          break;;
-        [nN][oO]|[nN])
-          echo "The deployment script can't be executed if Maven is not installed."
-          exit -1;;
-        *) echo "Please answer 'yes' or 'no'";;
-      esac
-    done
-    echo "Maven was successfully installed"
+# Function to install Maven on macOS
+install_maven_mac() {
+    echo "Installing Maven on macOS..."
+    # Confirm that Homebrew is installed. Install it otherwise
+    brew --version >/dev/null 2>/dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    if [ -n "$BASH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.bashrc"
+        add_homebrew_to_shell "$HOME/.bash_profile"
+    elif [ -n "$ZSH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.zshrc"
+        add_homebrew_to_shell "$HOME/.zprofile"
+    else
+        echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
+    fi
+    brew install maven
+    echo "Maven was successfully installed on macOS."
+}
+
+# Function to install Maven on Windows
+install_maven_windows() {
+    echo "Installing Maven on Windows..."
+    MAVEN_FOLDER="apache-maven-3.9.8"
+    MAVEN_FILE_NAME="$MAVEN_FOLDER-bin.zip"
+    MAVEN_VERSION="3.9.8"
+
+    DEFAULT_DRIVE=$(powershell.exe -C "(Get-WmiObject -Class Win32_OperatingSystem).SystemDrive")
+
+    curl "https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/$MAVEN_FILE_NAME" -o "$MAVEN_FILE_NAME"
+    mv "$MAVEN_FILE_NAME" "$DEFAULT_DRIVE\\$MAVEN_FILE_NAME"
+    echo "Extracting the downloaded package..."
+
+    unzip -qq "$DEFAULT_DRIVE/$MAVEN_FILE_NAME" -d "$DEFAULT_DRIVE/"
+    rm -f "$DEFAULT_DRIVE/$MAVEN_FILE_NAME"
+
+    # Append mvn path to System Path
+    appendMavenToPathCommand="\$oldPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine'); [System.Environment]::SetEnvironmentVariable('Path', \$oldPath + ';$DEFAULT_DRIVE/$MAVEN_FOLDER/bin', 'Machine')"
+    powershell.exe -Command "${appendMavenToPathCommand}"
+
+    # refresh current PATH to run mvn
+    export PATH="$PATH:$DEFAULT_DRIVE/$MAVEN_FOLDER/bin"
+
+    mvn --version
+    echo "Maven was successfully installed on Windows."
 }
 
 # Confirm that the user has updated the config file. Stop the execution otherwise
@@ -72,7 +139,20 @@ echo
 
 # Confirm that the AWS CLI is installed. Ask the user for confirmation and install it otherwise
 echo "The AWS CLI is required to deploy the Sample Solution App. Checking if it is installed in the system ..."
-aws --version > /dev/null 2> /dev/null || install_aws_cli
+# Check if AWS CLI is installed
+if check_aws_cli; then
+    echo "AWS CLI is already installed. No action required."
+else
+    # Check the operating system and call the appropriate installation function
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        install_aws_cli_mac
+    elif [[ "$OSTYPE" == "msys" ]]; then
+        install_aws_cli_windows
+    else
+        echo "Unsupported operating system. The script supports macOS and Windows only."
+        exit 1
+    fi
+fi
 
 echo
 
@@ -89,33 +169,60 @@ echo
 # Language-specific pre-requisites
 
 # Get the programming language from the input arguments
-language=""
-while getopts 'l:' flag; do
-  case "${flag}" in
-    l) language="${OPTARG}";;
-  esac
-done
+language=$1
+
+if [ -z "${language}" ]; then
+  echo "A programming language is not selected. Aborting..."
+  exit 1
+fi
 
 # If it's a Java app, confirm that Maven is installed
 if [ "$language" == "java" ]; then
-  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system ..."
-  mvn --version > /dev/null 2> /dev/null || install_maven
+  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system..."
+
+  if check_maven; then
+      echo "Maven is already installed. No action required."
+  else
+      # Check the operating system and call the appropriate installation function
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+          install_maven_mac
+      elif [[ "$OSTYPE" == "msys" ]]; then
+          install_maven_windows
+      else
+          echo "Unsupported operating system. The script supports macOS and Windows only."
+          exit 1
+      fi
+  fi
 fi
 
 # If it's a Python app, confirm that necessary Python packages are installed
 if [ "$language" == "python" ]; then
   echo "Certain Python packages are required to deploy a Python Sample Solution App. Checking if they are installed ..."
-  python3 -c "
-import pkg_resources
-import os
+  pythonCommand="import sys
+import subprocess
+from importlib.metadata import Distribution
 REQUIRED_PACKAGES = ['boto3', 'requests', 'setuptools']
+def install_package(package):
+    try:
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', package])
+        print(f'{package} has been installed successfully.')
+    except subprocess.CalledProcessError as e:
+        print(f'Error installing {package}.')
+
 for package in REQUIRED_PACKAGES:
   try:
-    dist = pkg_resources.get_distribution(package)
-    print('{} ({}) is installed'.format(dist.key, dist.version))
-  except pkg_resources.DistributionNotFound:
-    print('{} is NOT installed'.format(package))
-    print('Installing {} ...'.format(package))
-    os.system('python3 -m pip install {}'.format(package))
-  "
+        dist = Distribution.from_name(package)
+        print(f'{dist.metadata['Name']} ({dist.metadata['Version']}) is installed')
+  except ImportError:
+        print(f'{package} is NOT installed')
+        install_package(package)"
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    python3 -c "$pythonCommand"
+  elif [[ "$OSTYPE" == "msys" ]]; then
+    py -c "$pythonCommand"
+  else
+    echo "Unsupported operating system. The script supports macOS and Windows only."
+    exit 1
+  fi
 fi

--- a/use-cases/pricing/README.md
+++ b/use-cases/pricing/README.md
@@ -37,6 +37,8 @@ The pre-requisites for deploying the Sample Solution App to the AWS cloud are:
 * The [AWS CLI](https://aws.amazon.com/cli/)
     * If not present, it will be installed as part of the deployment script
 * The Python app requires the following packages: `boto3`, `requests`, and `setuptools`. If not present, they will be installed as part of the deployment script
+* [GitBash](https://git-scm.com/download/win)
+   * in case you use Windows in order to run the deployment script.
 
 ## Usage
 ### 1. Update config file
@@ -88,8 +90,8 @@ The deployment script will create a Sample Solution App in the AWS cloud.
 To execute the deployment script, follow the steps below.
 1. Identify the deployment script for the programming language you want for your Sample Solution App.
     1. For example, for the Python application the file is [app/scripts/python/python-app.sh](app/scripts/python/python-app.sh)
-2. Execute the script from your terminal
-    1. For example, to execute the Python deployment script in a Unix-based system, run `bash python-app.sh`
+2. Execute the script from your terminal or Git Bash
+    1. For example, to execute the Python deployment script in a Unix-based system or using Git Bash, run `bash python-app.sh`
 3. Wait for the CloudFormation stack creation to finish
     1. Navigate to [CloudFormation console](https://console.aws.amazon.com/cloudformation/home)
     2. Wait for the stack named **sp-api-app-\<language\>-*random_suffix*** to show status `CREATE_COMPLETE`
@@ -329,8 +331,8 @@ The deployment script creates a number of resources in the AWS cloud which you m
 To clean up these resources, follow the steps below.
 1. Identify the clean-up script for the programming language of the Sample Solution App deployed to the AWS cloud.
     1. For example, for the Python application the file is [app/scripts/python/python-app-clean.sh](app/scripts/python/python-app-clean.sh)
-2. Execute the script from your terminal
-    1. For example, to execute the Python clean-up script in a Unix-based system, run `bash python-app-clean.sh`
+2. Execute the script from your terminal or Git Bash
+    1. For example, to execute the Python clean-up script in a Unix-based system or using Git Bash, run `bash python-app-clean.sh`
 
 ### 7. Troubleshooting
 If the state machine execution fails, follow the steps below to identify the root-cause and retry the workflow

--- a/use-cases/pricing/app/scripts/shared/deploy-app.sh
+++ b/use-cases/pricing/app/scripts/shared/deploy-app.sh
@@ -17,7 +17,7 @@ case "${language}" in
 esac
 
 # Verify pre-requisites
-bash ../shared/pre-requisites.sh "$@"
+source ../shared/pre-requisites.sh $language
 if [ $? -ne 0 ]
 then
   echo "Verifying pre-requisites failed"
@@ -118,9 +118,13 @@ elif [ "$language" == "python" ]; then
   submit_price_handler="src/submit_price_handler.lambda_handler"
   calculate_new_price_handler="src/calculate_new_price_handler.lambda_handler"
 	(
-	  cd "${python_code_folder}" || exit
-	  zip -rq "${python_code_zip}" . -x "target/"
-	)
+    cd "${python_code_folder}" || exit
+    if command -v zip >/dev/null 2>&1; then
+      zip -rq "${python_code_zip}" . -x "target/"
+    elif [[ "$OSTYPE" == "msys"* ]]; then
+      powershell -Command "\$filestoArchive = Get-ChildItem -Path . -Exclude 'target'; Compress-Archive -Path \$filesToArchive -DestinationPath '${python_code_zip}'"
+    fi
+  )
 	AWS_ACCESS_KEY_ID=${access_key} AWS_SECRET_ACCESS_KEY=${secret_key} \
 	  aws s3 cp "${python_code_folder}${python_code_zip}" "s3://${bucket_name}/${code_s3_key}"
 fi

--- a/use-cases/pricing/app/scripts/shared/pre-requisites.sh
+++ b/use-cases/pricing/app/scripts/shared/pre-requisites.sh
@@ -1,25 +1,75 @@
 #!/bin/bash
 
-# This functions installs the AWS CLI
-install_aws_cli () {
+# Function to check if AWS CLI is installed
+check_aws_cli() {
+    if command -v aws >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to install AWS CLI on macOS
+install_aws_cli_mac() {
   while true; do
-    read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
-    case "${response}" in
-      [yY][eE][sS]|[yY])
-        echo "Installing the AWS CLI ..."
-        echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
-        curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-        echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
-        echo "You might be requested to enter your password in the next step."
-        sudo installer -pkg AWSCLIV2.pkg -target /
-        break;;
-      [nN][oO]|[nN])
-        echo "The deployment script can't be executed if the AWS CLI is not installed."
-        exit -1;;
-      *) echo "Please answer 'yes' or 'no'";;
-    esac
+      read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+      case "${response}" in
+        [yY][eE][sS]|[yY])
+          echo "Installing the AWS CLI on macOS..."
+          echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
+          curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+          echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
+          echo "You might be requested to enter your password in the next step."
+          sudo installer -pkg AWSCLIV2.pkg -target /
+          echo "The AWS CLI was successfully installed on macOS."
+          break;;
+        [nN][oO]|[nN])
+          echo "The deployment script can't be executed if the AWS CLI is not installed."
+          exit -1;;
+        *) echo "Please answer 'yes' or 'no'";;
+      esac
   done
-  echo "The AWS CLI was successfully installed"
+}
+
+# Function to install AWS CLI on Windows
+install_aws_cli_windows() {
+  while true; do
+        read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+        case "${response}" in
+          [yY][eE][sS]|[yY])
+            echo "Installing the AWS CLI on Windows..."
+            echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.msi."
+            curl "https://awscli.amazonaws.com/AWSCLIV2.msi" -o "AWSCLIV2.msi"
+
+            echo "Executing 'msiexec'. Installation started..."
+            echo "Please wait..."
+            msiexec //i AWSCLIV2.msi //quiet
+
+            # get path to aws cli and add it to current PATH
+            awsDirectory=$(powershell -C "(Get-ChildItem -Path 'C:\Program Files' -Recurse -Include aws.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty DirectoryName -First 1)")
+            awsPosixDirectory=$(echo "/$awsDirectory" | sed 's/\\/\//g' | sed 's/://')
+            export PATH="$PATH:${awsPosixDirectory}"
+
+            echo "The AWS CLI was successfully installed on Windows."
+            echo "Removing the installer..."
+            rm -f AWSCLIV2.msi
+            break;;
+          [nN][oO]|[nN])
+            echo "The deployment script can't be executed if the AWS CLI is not installed."
+            exit -1;;
+          *) echo "Please answer 'yes' or 'no'";;
+        esac
+    done
+}
+
+# Function to check if Maven is installed
+check_maven() {
+    if command -v mvn >/dev/null 2>&1; then
+        return 0
+    else
+        echo "Maven is not installed."
+        return 1
+    fi
 }
 
 add_homebrew_to_shell() {
@@ -27,32 +77,49 @@ add_homebrew_to_shell() {
   eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 }
 
-install_maven () {
-  while true; do
-      read -p "Maven is not installed in the system. Do you wish to install it now? [y/n] " response
-      case "${response}" in
-        [yY][eE][sS]|[yY])
-          echo "Installing Maven ..."
-          # Confirm that Homebrew is installed. Install it otherwise
-          brew --version >/dev/null 2> /dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          if [ -n "$BASH_VERSION" ]; then
-            add_homebrew_to_shell "$HOME/.bashrc"
-            add_homebrew_to_shell "$HOME/.bash_profile"
-          elif [ -n "$ZSH_VERSION" ]; then
-            add_homebrew_to_shell "$HOME/.zshrc"
-            add_homebrew_to_shell "$HOME/.zprofile"
-          else
-            echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
-          fi
-          brew install maven
-          break;;
-        [nN][oO]|[nN])
-          echo "The deployment script can't be executed if Maven is not installed."
-          exit -1;;
-        *) echo "Please answer 'yes' or 'no'";;
-      esac
-    done
-    echo "Maven was successfully installed"
+# Function to install Maven on macOS
+install_maven_mac() {
+    echo "Installing Maven on macOS..."
+    # Confirm that Homebrew is installed. Install it otherwise
+    brew --version >/dev/null 2>/dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    if [ -n "$BASH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.bashrc"
+        add_homebrew_to_shell "$HOME/.bash_profile"
+    elif [ -n "$ZSH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.zshrc"
+        add_homebrew_to_shell "$HOME/.zprofile"
+    else
+        echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
+    fi
+    brew install maven
+    echo "Maven was successfully installed on macOS."
+}
+
+# Function to install Maven on Windows
+install_maven_windows() {
+    echo "Installing Maven on Windows..."
+    MAVEN_FOLDER="apache-maven-3.9.8"
+    MAVEN_FILE_NAME="$MAVEN_FOLDER-bin.zip"
+    MAVEN_VERSION="3.9.8"
+
+    DEFAULT_DRIVE=$(powershell.exe -C "(Get-WmiObject -Class Win32_OperatingSystem).SystemDrive")
+
+    curl "https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/$MAVEN_FILE_NAME" -o "$MAVEN_FILE_NAME"
+    mv "$MAVEN_FILE_NAME" "$DEFAULT_DRIVE\\$MAVEN_FILE_NAME"
+    echo "Extracting the downloaded package..."
+
+    unzip -qq "$DEFAULT_DRIVE/$MAVEN_FILE_NAME" -d "$DEFAULT_DRIVE/"
+    rm -f "$DEFAULT_DRIVE/$MAVEN_FILE_NAME"
+
+    # Append mvn path to System Path
+    appendMavenToPathCommand="\$oldPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine'); [System.Environment]::SetEnvironmentVariable('Path', \$oldPath + ';$DEFAULT_DRIVE/$MAVEN_FOLDER/bin', 'Machine')"
+    powershell.exe -Command "${appendMavenToPathCommand}"
+
+    # refresh current PATH to run mvn
+    export PATH="$PATH:$DEFAULT_DRIVE/$MAVEN_FOLDER/bin"
+
+    mvn --version
+    echo "Maven was successfully installed on Windows."
 }
 
 # Confirm that the user has updated the config file. Stop the execution otherwise
@@ -72,7 +139,20 @@ echo
 
 # Confirm that the AWS CLI is installed. Ask the user for confirmation and install it otherwise
 echo "The AWS CLI is required to deploy the Sample Solution App. Checking if it is installed in the system ..."
-aws --version > /dev/null 2> /dev/null || install_aws_cli
+# Check if AWS CLI is installed
+if check_aws_cli; then
+    echo "AWS CLI is already installed. No action required."
+else
+    # Check the operating system and call the appropriate installation function
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        install_aws_cli_mac
+    elif [[ "$OSTYPE" == "msys" ]]; then
+        install_aws_cli_windows
+    else
+        echo "Unsupported operating system. The script supports macOS and Windows only."
+        exit 1
+    fi
+fi
 
 echo
 
@@ -89,33 +169,60 @@ echo
 # Language-specific pre-requisites
 
 # Get the programming language from the input arguments
-language=""
-while getopts 'l:' flag; do
-  case "${flag}" in
-    l) language="${OPTARG}";;
-  esac
-done
+language=$1
+
+if [ -z "${language}" ]; then
+  echo "A programming language is not selected. Aborting..."
+  exit 1
+fi
 
 # If it's a Java app, confirm that Maven is installed
 if [ "$language" == "java" ]; then
-  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system ..."
-  mvn --version > /dev/null 2> /dev/null || install_maven
+  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system..."
+
+  if check_maven; then
+      echo "Maven is already installed. No action required."
+  else
+      # Check the operating system and call the appropriate installation function
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+          install_maven_mac
+      elif [[ "$OSTYPE" == "msys" ]]; then
+          install_maven_windows
+      else
+          echo "Unsupported operating system. The script supports macOS and Windows only."
+          exit 1
+      fi
+  fi
 fi
 
 # If it's a Python app, confirm that necessary Python packages are installed
 if [ "$language" == "python" ]; then
   echo "Certain Python packages are required to deploy a Python Sample Solution App. Checking if they are installed ..."
-  python3 -c "
-import pkg_resources
-import os
+  pythonCommand="import sys
+import subprocess
+from importlib.metadata import Distribution
 REQUIRED_PACKAGES = ['boto3', 'requests', 'setuptools']
+def install_package(package):
+    try:
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', package])
+        print(f'{package} has been installed successfully.')
+    except subprocess.CalledProcessError as e:
+        print(f'Error installing {package}.')
+
 for package in REQUIRED_PACKAGES:
   try:
-    dist = pkg_resources.get_distribution(package)
-    print('{} ({}) is installed'.format(dist.key, dist.version))
-  except pkg_resources.DistributionNotFound:
-    print('{} is NOT installed'.format(package))
-    print('Installing {} ...'.format(package))
-    os.system('python3 -m pip install {}'.format(package))
-  "
+        dist = Distribution.from_name(package)
+        print(f'{dist.metadata['Name']} ({dist.metadata['Version']}) is installed')
+  except ImportError:
+        print(f'{package} is NOT installed')
+        install_package(package)"
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    python3 -c "$pythonCommand"
+  elif [[ "$OSTYPE" == "msys" ]]; then
+    py -c "$pythonCommand"
+  else
+    echo "Unsupported operating system. The script supports macOS and Windows only."
+    exit 1
+  fi
 fi

--- a/use-cases/pricing/code/java/pom.xml
+++ b/use-cases/pricing/code/java/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/use-cases/shipping-v2/README.md
+++ b/use-cases/shipping-v2/README.md
@@ -41,6 +41,8 @@ The pre-requisites for deploying the Sample Solution App to the AWS cloud are:
 * [Maven](https://maven.apache.org/)
   * Just for deploying a Java-based application.
   * If not present, it will be installed as part of the deployment script.
+* [GitBash](https://git-scm.com/download/win)
+    * in case you use Windows in order to run the deployment script.
 
 ## Usage
 ### 1. Update config file
@@ -133,8 +135,8 @@ The deployment script will create a Sample Solution App in the AWS cloud.
 To execute the deployment script, follow the steps below.
 1. Identify the deployment script for the programming language you want for your Sample Solution App.
    1. For example, for the Python application the file is `app/scripts/python/python-app.sh`.
-2. Execute the script from your terminal.
-   1. For example, to execute the Python deployment script in a Unix-based system, run `bash python-app.sh`.
+2. Execute the script from your terminal or Git Bash.
+   1. For example, to execute the Python deployment script in a Unix-based system or using Git Bash, run `bash python-app.sh`.
 3. Wait for the CloudFormation stack creation to finish.
    1. Navigate to [CloudFormation console](https://console.aws.amazon.com/cloudformation/home).
    2. Wait for the stack named **sp-api-app-\<language\>-*random_suffix*** to show status `CREATE_COMPLETE`.
@@ -284,8 +286,8 @@ To clean up these resources, follow the steps below.
    4. Confirm the objects deletion.
 2. Identify the clean-up script for the programming language of the Sample Solution App deployed to the AWS cloud.
    1. For example, for the Python application the file is `app/scripts/python/python-app-clean.sh`.
-3. Execute the script from your terminal.
-   1. For example, to execute the Python clean-up script in a Unix-based system, run `bash python-app-clean.sh`.
+3. Execute the script from your terminal or Git Bash.
+   1. For example, to execute the Python clean-up script in a Unix-based system or using Git Bash, run `bash python-app-clean.sh`.
    2. Wait for the script to finish.
 
 ### 6. Troubleshooting

--- a/use-cases/shipping-v2/app/scripts/shared/deploy-app.sh
+++ b/use-cases/shipping-v2/app/scripts/shared/deploy-app.sh
@@ -17,7 +17,7 @@ case "${language}" in
 esac
 
 # Verify pre-requisites
-bash ../shared/pre-requisites.sh "$@"
+source ../shared/pre-requisites.sh $language
 if [ $? -ne 0 ]
 then
   echo "Verifying pre-requisites failed"
@@ -109,9 +109,13 @@ if [ "$language" == "python" ]; then
   get_tracking_handler="src/get_tracking_handler.lambda_handler"
 
 	(
-	  cd "${python_code_folder}" || exit
-	  zip -rq "${python_code_zip}" . -x "target/"
-	)
+    cd "${python_code_folder}" || exit
+    if command -v zip >/dev/null 2>&1; then
+      zip -rq "${python_code_zip}" . -x "target/"
+    elif [[ "$OSTYPE" == "msys"* ]]; then
+      powershell -Command "\$filestoArchive = Get-ChildItem -Path . -Exclude 'target'; Compress-Archive -Path \$filesToArchive -DestinationPath '${python_code_zip}'"
+    fi
+  )
 	AWS_ACCESS_KEY_ID=${access_key} AWS_SECRET_ACCESS_KEY=${secret_key} \
 	  aws s3 cp "${python_code_folder}${python_code_zip}" "s3://${bucket_name}/${code_s3_key}"
 fi

--- a/use-cases/shipping-v2/app/scripts/shared/pre-requisites.sh
+++ b/use-cases/shipping-v2/app/scripts/shared/pre-requisites.sh
@@ -1,62 +1,125 @@
 #!/bin/bash
 
-# This functions installs the AWS CLI
-install_aws_cli () {
-  while true; do
-    read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
-    case "${response}" in
-      [yY][eE][sS]|[yY])
-        echo "Installing the AWS CLI ..."
-        echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
-        curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-        echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
-        echo "You might be requested to enter your password in the next step."
-        sudo installer -pkg AWSCLIV2.pkg -target /
-        break;;
-      [nN][oO]|[nN])
-        echo "The deployment script can't be executed if the AWS CLI is not installed."
-        exit -1;;
-      *) echo "Please answer 'yes' or 'no'";;
-    esac
-  done
-  echo "The AWS CLI was successfully installed"
+# Function to check if AWS CLI is installed
+check_aws_cli() {
+    if command -v aws >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
 }
 
+# Function to install AWS CLI on macOS
+install_aws_cli_mac() {
+  while true; do
+      read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+      case "${response}" in
+        [yY][eE][sS]|[yY])
+          echo "Installing the AWS CLI on macOS..."
+          echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
+          curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+          echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
+          echo "You might be requested to enter your password in the next step."
+          sudo installer -pkg AWSCLIV2.pkg -target /
+          echo "The AWS CLI was successfully installed on macOS."
+          break;;
+        [nN][oO]|[nN])
+          echo "The deployment script can't be executed if the AWS CLI is not installed."
+          exit -1;;
+        *) echo "Please answer 'yes' or 'no'";;
+      esac
+  done
+}
+
+# Function to install AWS CLI on Windows
+install_aws_cli_windows() {
+  while true; do
+        read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+        case "${response}" in
+          [yY][eE][sS]|[yY])
+            echo "Installing the AWS CLI on Windows..."
+            echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.msi."
+            curl "https://awscli.amazonaws.com/AWSCLIV2.msi" -o "AWSCLIV2.msi"
+
+            echo "Executing 'msiexec'. Installation started..."
+            echo "Please wait..."
+            msiexec //i AWSCLIV2.msi //quiet
+
+            # get path to aws cli and add it to current PATH
+            awsDirectory=$(powershell -C "(Get-ChildItem -Path 'C:\Program Files' -Recurse -Include aws.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty DirectoryName -First 1)")
+            awsPosixDirectory=$(echo "/$awsDirectory" | sed 's/\\/\//g' | sed 's/://')
+            export PATH="$PATH:${awsPosixDirectory}"
+
+            echo "The AWS CLI was successfully installed on Windows."
+            echo "Removing the installer..."
+            rm -f AWSCLIV2.msi
+            break;;
+          [nN][oO]|[nN])
+            echo "The deployment script can't be executed if the AWS CLI is not installed."
+            exit -1;;
+          *) echo "Please answer 'yes' or 'no'";;
+        esac
+    done
+}
+
+# Function to check if Maven is installed
+check_maven() {
+    if command -v mvn >/dev/null 2>&1; then
+        return 0
+    else
+        echo "Maven is not installed."
+        return 1
+    fi
+}
 
 add_homebrew_to_shell() {
   echo 'eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)' >> "$1"
   eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 }
 
+# Function to install Maven on macOS
+install_maven_mac() {
+    echo "Installing Maven on macOS..."
+    # Confirm that Homebrew is installed. Install it otherwise
+    brew --version >/dev/null 2>/dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    if [ -n "$BASH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.bashrc"
+        add_homebrew_to_shell "$HOME/.bash_profile"
+    elif [ -n "$ZSH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.zshrc"
+        add_homebrew_to_shell "$HOME/.zprofile"
+    else
+        echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
+    fi
+    brew install maven
+    echo "Maven was successfully installed on macOS."
+}
 
-install_maven () {
-  while true; do
-      read -p "Maven is not installed in the system. Do you wish to install it now? [y/n] " response
-      case "${response}" in
-        [yY][eE][sS]|[yY])
-          echo "Installing Maven ..."
-          # Confirm that Homebrew is installed. Install it otherwise
-          brew --version >/dev/null 2> /dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          if [ -n "$BASH_VERSION" ]; then
-            add_homebrew_to_shell "$HOME/.bashrc"
-            add_homebrew_to_shell "$HOME/.bash_profile"
-          elif [ -n "$ZSH_VERSION" ]; then
-            add_homebrew_to_shell "$HOME/.zshrc"
-            add_homebrew_to_shell "$HOME/.zprofile"
-          else
-            echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
-          fi
+# Function to install Maven on Windows
+install_maven_windows() {
+    echo "Installing Maven on Windows..."
+    MAVEN_FOLDER="apache-maven-3.9.8"
+    MAVEN_FILE_NAME="$MAVEN_FOLDER-bin.zip"
+    MAVEN_VERSION="3.9.8"
 
+    DEFAULT_DRIVE=$(powershell.exe -C "(Get-WmiObject -Class Win32_OperatingSystem).SystemDrive")
 
-          brew install maven
-          break;;
-        [nN][oO]|[nN])
-          echo "The deployment script can't be executed if Maven is not installed."
-          exit -1;;
-        *) echo "Please answer 'yes' or 'no'";;
-      esac
-    done
-    echo "Maven was successfully installed"
+    curl "https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/$MAVEN_FILE_NAME" -o "$MAVEN_FILE_NAME"
+    mv "$MAVEN_FILE_NAME" "$DEFAULT_DRIVE\\$MAVEN_FILE_NAME"
+    echo "Extracting the downloaded package..."
+
+    unzip -qq "$DEFAULT_DRIVE/$MAVEN_FILE_NAME" -d "$DEFAULT_DRIVE/"
+    rm -f "$DEFAULT_DRIVE/$MAVEN_FILE_NAME"
+
+    # Append mvn path to System Path
+    appendMavenToPathCommand="\$oldPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine'); [System.Environment]::SetEnvironmentVariable('Path', \$oldPath + ';$DEFAULT_DRIVE/$MAVEN_FOLDER/bin', 'Machine')"
+    powershell.exe -Command "${appendMavenToPathCommand}"
+
+    # refresh current PATH to run mvn
+    export PATH="$PATH:$DEFAULT_DRIVE/$MAVEN_FOLDER/bin"
+
+    mvn --version
+    echo "Maven was successfully installed on Windows."
 }
 
 # Confirm that the user has updated the config file. Stop the execution otherwise
@@ -76,7 +139,20 @@ echo
 
 # Confirm that the AWS CLI is installed. Ask the user for confirmation and install it otherwise
 echo "The AWS CLI is required to deploy the Sample Solution App. Checking if it is installed in the system ..."
-aws --version > /dev/null 2> /dev/null || install_aws_cli
+# Check if AWS CLI is installed
+if check_aws_cli; then
+    echo "AWS CLI is already installed. No action required."
+else
+    # Check the operating system and call the appropriate installation function
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        install_aws_cli_mac
+    elif [[ "$OSTYPE" == "msys" ]]; then
+        install_aws_cli_windows
+    else
+        echo "Unsupported operating system. The script supports macOS and Windows only."
+        exit 1
+    fi
+fi
 
 echo
 
@@ -93,28 +169,66 @@ echo
 # Language-specific pre-requisites
 
 # Get the programming language from the input arguments
-language=""
-while getopts 'l:' flag; do
-  case "${flag}" in
-    l) language="${OPTARG}";;
-  esac
-done
+language=$1
 
+if [ -z "${language}" ]; then
+  echo "A programming language is not selected. Aborting..."
+  exit 1
+fi
+
+# If it's a Java app, confirm that Maven is installed
+if [ "$language" == "java" ]; then
+  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system..."
+
+  if check_maven; then
+      echo "Maven is already installed. No action required."
+  else
+      # Check the operating system and call the appropriate installation function
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+          install_maven_mac
+      elif [[ "$OSTYPE" == "msys" ]]; then
+          install_maven_windows
+      else
+          echo "Unsupported operating system. The script supports macOS and Windows only."
+          exit 1
+      fi
+  fi
+fi
 
 # If it's a Python app, confirm that necessary Python packages are installed
 if [ "$language" == "python" ]; then
-	echo "Certain Python packages are required to deploy a Python Sample Solution App. Checking if they are installed ..."
-	python3 -c "
-import pkg_resources
-import os
+  echo "Certain Python packages are required to deploy a Python Sample Solution App. Checking if they are installed ..."
+  pythonCommand="import sys
+import subprocess
+from importlib.metadata import Distribution
 REQUIRED_PACKAGES = ['boto3', 'requests', 'setuptools', 'stringcase', 'dataclasses-json']
+def install_package(package):
+    try:
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', package])
+        print(f'{package} has been installed successfully.')
+    except subprocess.CalledProcessError as e:
+        print(f'Error installing {package}.')
+
 for package in REQUIRED_PACKAGES:
-	try:
-	  dist = pkg_resources.get_distribution(package)
-	  print('{} ({}) is installed'.format(dist.key, dist.version))
-	except pkg_resources.DistributionNotFound:
-	  print('{} is NOT installed'.format(package))
-	  print('Installing {} ...'.format(package))
-	  os.system('python3 -m pip install {}'.format(package))
-	"
+  try:
+        dist = Distribution.from_name(package)
+        print(f'{dist.metadata['Name']} ({dist.metadata['Version']}) is installed')
+  except ImportError:
+        print(f'{package} is NOT installed')
+        install_package(package)"
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    python3 -c "$pythonCommand"
+  elif [[ "$OSTYPE" == "msys" ]]; then
+    py -c "$pythonCommand"
+  else
+    echo "Unsupported operating system. The script supports macOS and Windows only."
+    exit 1
+  fi
+fi
+
+# If it's a CSharp app, install Amazon lambda tools or update if already installed
+if [ "$language" == "csharp" ]; then
+echo "Certain Dotnet packages are required to deploy a Csharp Sample Solution App. Checking if they are installed ..."
+dotnet tool install -g Amazon.Lambda.Tools || dotnet tool update -g Amazon.Lambda.Tools
 fi

--- a/use-cases/solicitations/README.md
+++ b/use-cases/solicitations/README.md
@@ -32,6 +32,8 @@ The pre-requisites for deploying the Sample Solution App to the AWS cloud are:
 * The [AWS CLI](https://aws.amazon.com/cli/)
     * If not present, it will be installed as part of the deployment script
 * The Python app requires the following packages: `boto3`, `requests`, and `setuptools`. If not present, they will be installed as part of the deployment script
+* [GitBash](https://git-scm.com/download/win)
+    * in case you use Windows in order to run the deployment script.
 
 ## Usage
 ### 1. Update config file
@@ -116,8 +118,8 @@ The deployment script will create a Sample Solution App in the AWS cloud.
 To execute the deployment script, follow the steps below.
 1. Identify the deployment script for the programming language you want for your Sample Solution App.
    1. For example, for the Python application the file is [app/scripts/python/python-app.sh](app/scripts/python/python-app.sh)
-2. Execute the script from your terminal
-   1. For example, to execute the Python deployment script in a Unix-based system, run `bash python-app.sh`
+2. Execute the script from your terminal or Git Bash
+   1. For example, to execute the Python deployment script in a Unix-based system or using Git Bash, run `bash python-app.sh`
 3. Wait for the CloudFormation stack creation to finish
     1. Navigate to [CloudFormation console](https://console.aws.amazon.com/cloudformation/home)
     2. Wait for the stack named **sp-api-app-\<language\>-*random_suffix*** to show status `CREATE_COMPLETE`
@@ -178,8 +180,8 @@ The deployment script creates a number of resources in the AWS cloud which you m
 To clean up these resources, follow the steps below.
 1. Identify the clean-up script for the programming language of the Sample Solution App deployed to the AWS cloud.
     1. For example, for the Python application the file is [app/scripts/python/python-app-clean.sh](app/scripts/python/python-app-clean.sh)
-2. Execute the script from your terminal
-    1. For example, to execute the Python clean-up script in a Unix-based system, run `bash python-app-clean.sh`
+2. Execute the script from your terminal or Git Bash
+    1. For example, to execute the Python clean-up script in a Unix-based system or using Git Bash, run `bash python-app-clean.sh`
 
 ### 7. Troubleshooting
 If the state machine execution fails, follow the steps below to identify the root-cause and retry the workflow

--- a/use-cases/solicitations/app/scripts/shared/deploy-app.sh
+++ b/use-cases/solicitations/app/scripts/shared/deploy-app.sh
@@ -17,7 +17,7 @@ case "${language}" in
 esac
 
 # Verify pre-requisites
-bash ../shared/pre-requisites.sh "$@"
+source ../shared/pre-requisites.sh $language
 if [ $? -ne 0 ]
 then
   echo "Verifying pre-requisites failed"
@@ -100,7 +100,11 @@ if [ "$language" == "python" ]; then
   subscribe_notifications_handler="subscribe_notifications_handler.lambda_handler"
   (
     cd "${python_code_folder}src" || exit
-    zip -rq "${python_code_folder}${python_code_zip}" .
+    if command -v zip >/dev/null 2>&1; then
+      zip -rq "${python_code_folder}${python_code_zip}" .
+    elif [[ "$OSTYPE" == "msys"* ]]; then
+      powershell -Command "Compress-Archive -Path '.' -DestinationPath '${python_code_folder}${python_code_zip}'"
+    fi
   )
   AWS_ACCESS_KEY_ID=${access_key} AWS_SECRET_ACCESS_KEY=${secret_key} \
     aws s3 cp "${python_code_folder}${python_code_zip}" "s3://${bucket_name}/${code_s3_key}"

--- a/use-cases/solicitations/app/scripts/shared/pre-requisites.sh
+++ b/use-cases/solicitations/app/scripts/shared/pre-requisites.sh
@@ -1,25 +1,75 @@
 #!/bin/bash
 
-# This functions installs the AWS CLI
-install_aws_cli () {
+# Function to check if AWS CLI is installed
+check_aws_cli() {
+    if command -v aws >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to install AWS CLI on macOS
+install_aws_cli_mac() {
   while true; do
-    read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
-    case "${response}" in
-      [yY][eE][sS]|[yY])
-        echo "Installing the AWS CLI ..."
-        echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
-        curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-        echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
-        echo "You might be requested to enter your password in the next step."
-        sudo installer -pkg AWSCLIV2.pkg -target /
-        break;;
-      [nN][oO]|[nN])
-        echo "The deployment script can't be executed if the AWS CLI is not installed."
-        exit -1;;
-      *) echo "Please answer 'yes' or 'no'";;
-    esac
+      read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+      case "${response}" in
+        [yY][eE][sS]|[yY])
+          echo "Installing the AWS CLI on macOS..."
+          echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
+          curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+          echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
+          echo "You might be requested to enter your password in the next step."
+          sudo installer -pkg AWSCLIV2.pkg -target /
+          echo "The AWS CLI was successfully installed on macOS."
+          break;;
+        [nN][oO]|[nN])
+          echo "The deployment script can't be executed if the AWS CLI is not installed."
+          exit -1;;
+        *) echo "Please answer 'yes' or 'no'";;
+      esac
   done
-  echo "The AWS CLI was successfully installed"
+}
+
+# Function to install AWS CLI on Windows
+install_aws_cli_windows() {
+  while true; do
+        read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+        case "${response}" in
+          [yY][eE][sS]|[yY])
+            echo "Installing the AWS CLI on Windows..."
+            echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.msi."
+            curl "https://awscli.amazonaws.com/AWSCLIV2.msi" -o "AWSCLIV2.msi"
+
+            echo "Executing 'msiexec'. Installation started..."
+            echo "Please wait..."
+            msiexec //i AWSCLIV2.msi //quiet
+
+            # get path to aws cli and add it to current PATH
+            awsDirectory=$(powershell -C "(Get-ChildItem -Path 'C:\Program Files' -Recurse -Include aws.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty DirectoryName -First 1)")
+            awsPosixDirectory=$(echo "/$awsDirectory" | sed 's/\\/\//g' | sed 's/://')
+            export PATH="$PATH:${awsPosixDirectory}"
+
+            echo "The AWS CLI was successfully installed on Windows."
+            echo "Removing the installer..."
+            rm -f AWSCLIV2.msi
+            break;;
+          [nN][oO]|[nN])
+            echo "The deployment script can't be executed if the AWS CLI is not installed."
+            exit -1;;
+          *) echo "Please answer 'yes' or 'no'";;
+        esac
+    done
+}
+
+# Function to check if Maven is installed
+check_maven() {
+    if command -v mvn >/dev/null 2>&1; then
+        return 0
+    else
+        echo "Maven is not installed."
+        return 1
+    fi
 }
 
 add_homebrew_to_shell() {
@@ -27,32 +77,49 @@ add_homebrew_to_shell() {
   eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 }
 
-install_maven () {
-  while true; do
-      read -p "Maven is not installed in the system. Do you wish to install it now? [y/n] " response
-      case "${response}" in
-        [yY][eE][sS]|[yY])
-          echo "Installing Maven ..."
-          # Confirm that Homebrew is installed. Install it otherwise
-          brew --version >/dev/null 2> /dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          if [ -n "$BASH_VERSION" ]; then
-            add_homebrew_to_shell "$HOME/.bashrc"
-            add_homebrew_to_shell "$HOME/.bash_profile"
-          elif [ -n "$ZSH_VERSION" ]; then
-            add_homebrew_to_shell "$HOME/.zshrc"
-            add_homebrew_to_shell "$HOME/.zprofile"
-          else
-            echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
-          fi
-          brew install maven
-          break;;
-        [nN][oO]|[nN])
-          echo "The deployment script can't be executed if Maven is not installed."
-          exit -1;;
-        *) echo "Please answer 'yes' or 'no'";;
-      esac
-    done
-    echo "Maven was successfully installed"
+# Function to install Maven on macOS
+install_maven_mac() {
+    echo "Installing Maven on macOS..."
+    # Confirm that Homebrew is installed. Install it otherwise
+    brew --version >/dev/null 2>/dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    if [ -n "$BASH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.bashrc"
+        add_homebrew_to_shell "$HOME/.bash_profile"
+    elif [ -n "$ZSH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.zshrc"
+        add_homebrew_to_shell "$HOME/.zprofile"
+    else
+        echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
+    fi
+    brew install maven
+    echo "Maven was successfully installed on macOS."
+}
+
+# Function to install Maven on Windows
+install_maven_windows() {
+    echo "Installing Maven on Windows..."
+    MAVEN_FOLDER="apache-maven-3.9.8"
+    MAVEN_FILE_NAME="$MAVEN_FOLDER-bin.zip"
+    MAVEN_VERSION="3.9.8"
+
+    DEFAULT_DRIVE=$(powershell.exe -C "(Get-WmiObject -Class Win32_OperatingSystem).SystemDrive")
+
+    curl "https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/$MAVEN_FILE_NAME" -o "$MAVEN_FILE_NAME"
+    mv "$MAVEN_FILE_NAME" "$DEFAULT_DRIVE\\$MAVEN_FILE_NAME"
+    echo "Extracting the downloaded package..."
+
+    unzip -qq "$DEFAULT_DRIVE/$MAVEN_FILE_NAME" -d "$DEFAULT_DRIVE/"
+    rm -f "$DEFAULT_DRIVE/$MAVEN_FILE_NAME"
+
+    # Append mvn path to System Path
+    appendMavenToPathCommand="\$oldPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine'); [System.Environment]::SetEnvironmentVariable('Path', \$oldPath + ';$DEFAULT_DRIVE/$MAVEN_FOLDER/bin', 'Machine')"
+    powershell.exe -Command "${appendMavenToPathCommand}"
+
+    # refresh current PATH to run mvn
+    export PATH="$PATH:$DEFAULT_DRIVE/$MAVEN_FOLDER/bin"
+
+    mvn --version
+    echo "Maven was successfully installed on Windows."
 }
 
 # Confirm that the user has updated the config file. Stop the execution otherwise
@@ -72,7 +139,20 @@ echo
 
 # Confirm that the AWS CLI is installed. Ask the user for confirmation and install it otherwise
 echo "The AWS CLI is required to deploy the Sample Solution App. Checking if it is installed in the system ..."
-aws --version > /dev/null 2> /dev/null || install_aws_cli
+# Check if AWS CLI is installed
+if check_aws_cli; then
+    echo "AWS CLI is already installed. No action required."
+else
+    # Check the operating system and call the appropriate installation function
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        install_aws_cli_mac
+    elif [[ "$OSTYPE" == "msys" ]]; then
+        install_aws_cli_windows
+    else
+        echo "Unsupported operating system. The script supports macOS and Windows only."
+        exit 1
+    fi
+fi
 
 echo
 
@@ -89,29 +169,62 @@ echo
 # Language-specific pre-requisites
 
 # Get the programming language from the input arguments
-language=""
-while getopts 'l:' flag; do
-  case "${flag}" in
-    l) language="${OPTARG}";;
-  esac
-done
+language=$1
+
+if [ -z "${language}" ]; then
+  echo "A programming language is not selected. Aborting..."
+  exit 1
+fi
+
+# If it's a Java app, confirm that Maven is installed
+if [ "$language" == "java" ]; then
+  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system..."
+
+  if check_maven; then
+      echo "Maven is already installed. No action required."
+  else
+      # Check the operating system and call the appropriate installation function
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+          install_maven_mac
+      elif [[ "$OSTYPE" == "msys" ]]; then
+          install_maven_windows
+      else
+          echo "Unsupported operating system. The script supports macOS and Windows only."
+          exit 1
+      fi
+  fi
+fi
 
 # If it's a Python app, confirm that necessary Python packages are installed
 if [ "$language" == "python" ]; then
   echo "Certain Python packages are required to deploy a Python Sample Solution App. Checking if they are installed ..."
-  python3 -c "
-import pkg_resources
-import os
+  pythonCommand="import sys
+import subprocess
+from importlib.metadata import Distribution
 REQUIRED_PACKAGES = ['boto3', 'requests', 'setuptools']
+def install_package(package):
+    try:
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', package])
+        print(f'{package} has been installed successfully.')
+    except subprocess.CalledProcessError as e:
+        print(f'Error installing {package}.')
+
 for package in REQUIRED_PACKAGES:
   try:
-    dist = pkg_resources.get_distribution(package)
-    print('{} ({}) is installed'.format(dist.key, dist.version))
-  except pkg_resources.DistributionNotFound:
-    print('{} is NOT installed'.format(package))
-    print('Installing {} ...'.format(package))
-    os.system('python3 -m pip install {}'.format(package))
-  "
+        dist = Distribution.from_name(package)
+        print(f'{dist.metadata['Name']} ({dist.metadata['Version']}) is installed')
+  except ImportError:
+        print(f'{package} is NOT installed')
+        install_package(package)"
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    python3 -c "$pythonCommand"
+  elif [[ "$OSTYPE" == "msys" ]]; then
+    py -c "$pythonCommand"
+  else
+    echo "Unsupported operating system. The script supports macOS and Windows only."
+    exit 1
+  fi
 fi
 
 # If it's a CSharp app, install Amazon lambda tools or update if already installed

--- a/use-cases/vendor-direct-fulfillment/README.md
+++ b/use-cases/vendor-direct-fulfillment/README.md
@@ -36,6 +36,8 @@ The pre-requisites for deploying the Sample Solution App to the AWS cloud are:
     * If not present, it will be installed as part of the deployment script
 * The CSharp app requires Amazon Lambda tools .net package
     * If not present, it will be installed as part of the deployment script
+* [GitBash](https://git-scm.com/download/win)
+    * in case you use Windows in order to run the deployment script.
 
 ## Usage
 ### 1. Update config file
@@ -121,8 +123,8 @@ The deployment script will create a Sample Solution App in the AWS cloud.
 To execute the deployment script, follow the steps below.
 1. Identify the deployment script for the programming language you want for your Sample Solution App.
     1. For example, for the Csharp application the file is `app/scripts/csharp/csharp-app.sh`
-2. Execute the script from your terminal
-    1. For example, to execute the Csharp deployment script in a Unix-based system, run `bash csharp-app.sh`
+2. Execute the script from your terminal or Git Bash
+    1. For example, to execute the Csharp deployment script in a Unix-based system or using Git Bash, run `bash csharp-app.sh`
 3. Wait for the AWS CloudFormation stack creation to finish
     1. Navigate to [AWS CloudFormation Console](https://console.aws.amazon.com/cloudformation/home)
     2. Wait for the stack named sp-api-app-random_suffix to show status `CREATE_COMPLETE`
@@ -150,8 +152,8 @@ The deployment script creates a number of resources in the AWS cloud which you m
 To clean-up these resources, follow the steps below.
 1. Identify the clean-up script for the programming language of the Sample Solution App deployed to the AWS cloud.
     1. For example, for the Csharp application the file is `app/scripts/csharp/csharp-app-clean.sh`
-2. Execute the script from your terminal
-    1. For example, to execute the Csharp clean-up script in a Unix-based system, run `bash csharp-app-clean.sh`
+2. Execute the script from your terminal or Git Bash
+    1. For example, to execute the Csharp clean-up script in a Unix-based system or using Git Bash, run `bash csharp-app-clean.sh`
 
 ### 6. Troubleshooting
 If the state machine execution fails, follow the steps below to identify the root-cause and retry the workflow

--- a/use-cases/vendor-direct-fulfillment/app/scripts/shared/deploy-app.sh
+++ b/use-cases/vendor-direct-fulfillment/app/scripts/shared/deploy-app.sh
@@ -19,7 +19,7 @@ case "${language}" in
 esac
 
 # Verify pre-requisites
-bash ../shared/pre-requisites.sh "$@"
+source ../shared/pre-requisites.sh $language
 if [ $? -ne 0 ]
 then
   echo "Verifying pre-requisites failed"
@@ -109,8 +109,11 @@ elif [ "$language" == "javascript" ]; then
   lambda_func_handler="index.handler"
   (
     cd "${js_code_folder}src" || exit
-    npm install
-    zip -rq "${js_code_folder}${js_code_zip}" .
+    if command -v zip >/dev/null 2>&1; then
+      zip -rq "${js_code_folder}${js_code_zip}" .
+    elif [[ "$OSTYPE" == "msys"* ]]; then
+      powershell -Command "Compress-Archive -Path '.' -DestinationPath '${js_code_folder}${js_code_zip}'"
+    fi
   )
   AWS_ACCESS_KEY_ID=${access_key} AWS_SECRET_ACCESS_KEY=${secret_key} \
     aws s3 cp "${js_code_folder}${js_code_zip}" "s3://${bucket_name}/${code_s3_key}"
@@ -126,7 +129,11 @@ elif [ "$language" == "python" ]; then
   lambda_func_handler="DummyLambdaHandler.lambda_handler"
   (
     cd "${python_code_folder}src" || exit
-    zip -rq "${python_code_folder}${python_code_zip}" .
+    if command -v zip >/dev/null 2>&1; then
+      zip -rq "${python_code_folder}${python_code_zip}" .
+    elif [[ "$OSTYPE" == "msys"* ]]; then
+      powershell -Command "Compress-Archive -Path '.' -DestinationPath '${python_code_folder}${python_code_zip}'"
+    fi
   )
   AWS_ACCESS_KEY_ID=${access_key} AWS_SECRET_ACCESS_KEY=${secret_key} \
     aws s3 cp "${python_code_folder}${python_code_zip}" "s3://${bucket_name}/${code_s3_key}"

--- a/use-cases/vendor-direct-fulfillment/app/scripts/shared/pre-requisites.sh
+++ b/use-cases/vendor-direct-fulfillment/app/scripts/shared/pre-requisites.sh
@@ -1,25 +1,75 @@
 #!/bin/bash
 
-# This functions installs the AWS CLI
-install_aws_cli () {
+# Function to check if AWS CLI is installed
+check_aws_cli() {
+    if command -v aws >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to install AWS CLI on macOS
+install_aws_cli_mac() {
   while true; do
-    read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
-    case "${response}" in
-      [yY][eE][sS]|[yY])
-        echo "Installing the AWS CLI ..."
-        echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
-        curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-        echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
-        echo "You might be requested to enter your password in the next step."
-        sudo installer -pkg AWSCLIV2.pkg -target /
-        break;;
-      [nN][oO]|[nN])
-        echo "The deployment script can't be executed if the AWS CLI is not installed."
-        exit -1;;
-      *) echo "Please answer 'yes' or 'no'";;
-    esac
+      read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+      case "${response}" in
+        [yY][eE][sS]|[yY])
+          echo "Installing the AWS CLI on macOS..."
+          echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.pkg."
+          curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+          echo "Executing 'sudo installer -pkg AWSCLIV2.pkg -target'."
+          echo "You might be requested to enter your password in the next step."
+          sudo installer -pkg AWSCLIV2.pkg -target /
+          echo "The AWS CLI was successfully installed on macOS."
+          break;;
+        [nN][oO]|[nN])
+          echo "The deployment script can't be executed if the AWS CLI is not installed."
+          exit -1;;
+        *) echo "Please answer 'yes' or 'no'";;
+      esac
   done
-  echo "The AWS CLI was successfully installed"
+}
+
+# Function to install AWS CLI on Windows
+install_aws_cli_windows() {
+  while true; do
+        read -p "The AWS CLI is not installed in the system. Do you wish to install it now? [y/n] " response
+        case "${response}" in
+          [yY][eE][sS]|[yY])
+            echo "Installing the AWS CLI on Windows..."
+            echo "Downloading installation package from https://awscli.amazonaws.com/AWSCLIV2.msi."
+            curl "https://awscli.amazonaws.com/AWSCLIV2.msi" -o "AWSCLIV2.msi"
+
+            echo "Executing 'msiexec'. Installation started..."
+            echo "Please wait..."
+            msiexec //i AWSCLIV2.msi //quiet
+
+            # get path to aws cli and add it to current PATH
+            awsDirectory=$(powershell -C "(Get-ChildItem -Path 'C:\Program Files' -Recurse -Include aws.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty DirectoryName -First 1)")
+            awsPosixDirectory=$(echo "/$awsDirectory" | sed 's/\\/\//g' | sed 's/://')
+            export PATH="$PATH:${awsPosixDirectory}"
+
+            echo "The AWS CLI was successfully installed on Windows."
+            echo "Removing the installer..."
+            rm -f AWSCLIV2.msi
+            break;;
+          [nN][oO]|[nN])
+            echo "The deployment script can't be executed if the AWS CLI is not installed."
+            exit -1;;
+          *) echo "Please answer 'yes' or 'no'";;
+        esac
+    done
+}
+
+# Function to check if Maven is installed
+check_maven() {
+    if command -v mvn >/dev/null 2>&1; then
+        return 0
+    else
+        echo "Maven is not installed."
+        return 1
+    fi
 }
 
 add_homebrew_to_shell() {
@@ -27,32 +77,49 @@ add_homebrew_to_shell() {
   eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 }
 
-install_maven () {
-  while true; do
-      read -p "Maven is not installed in the system. Do you wish to install it now? [y/n] " response
-      case "${response}" in
-        [yY][eE][sS]|[yY])
-          echo "Installing Maven ..."
-          # Confirm that Homebrew is installed. Install it otherwise
-          brew --version >/dev/null 2> /dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          if [ -n "$BASH_VERSION" ]; then
-            add_homebrew_to_shell "$HOME/.bashrc"
-            add_homebrew_to_shell "$HOME/.bash_profile"
-          elif [ -n "$ZSH_VERSION" ]; then
-            add_homebrew_to_shell "$HOME/.zshrc"
-            add_homebrew_to_shell "$HOME/.zprofile"
-          else
-            echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
-          fi
-          brew install maven
-          break;;
-        [nN][oO]|[nN])
-          echo "The deployment script can't be executed if Maven is not installed."
-          exit -1;;
-        *) echo "Please answer 'yes' or 'no'";;
-      esac
-    done
-    echo "Maven was successfully installed"
+# Function to install Maven on macOS
+install_maven_mac() {
+    echo "Installing Maven on macOS..."
+    # Confirm that Homebrew is installed. Install it otherwise
+    brew --version >/dev/null 2>/dev/null || xcode-select --install; /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    if [ -n "$BASH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.bashrc"
+        add_homebrew_to_shell "$HOME/.bash_profile"
+    elif [ -n "$ZSH_VERSION" ]; then
+        add_homebrew_to_shell "$HOME/.zshrc"
+        add_homebrew_to_shell "$HOME/.zprofile"
+    else
+        echo "Warning: Unsupported shell. Please add Homebrew configuration manually."
+    fi
+    brew install maven
+    echo "Maven was successfully installed on macOS."
+}
+
+# Function to install Maven on Windows
+install_maven_windows() {
+    echo "Installing Maven on Windows..."
+    MAVEN_FOLDER="apache-maven-3.9.8"
+    MAVEN_FILE_NAME="$MAVEN_FOLDER-bin.zip"
+    MAVEN_VERSION="3.9.8"
+
+    DEFAULT_DRIVE=$(powershell.exe -C "(Get-WmiObject -Class Win32_OperatingSystem).SystemDrive")
+
+    curl "https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/$MAVEN_FILE_NAME" -o "$MAVEN_FILE_NAME"
+    mv "$MAVEN_FILE_NAME" "$DEFAULT_DRIVE\\$MAVEN_FILE_NAME"
+    echo "Extracting the downloaded package..."
+
+    unzip -qq "$DEFAULT_DRIVE/$MAVEN_FILE_NAME" -d "$DEFAULT_DRIVE/"
+    rm -f "$DEFAULT_DRIVE/$MAVEN_FILE_NAME"
+
+    # Append mvn path to System Path
+    appendMavenToPathCommand="\$oldPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine'); [System.Environment]::SetEnvironmentVariable('Path', \$oldPath + ';$DEFAULT_DRIVE/$MAVEN_FOLDER/bin', 'Machine')"
+    powershell.exe -Command "${appendMavenToPathCommand}"
+
+    # refresh current PATH to run mvn
+    export PATH="$PATH:$DEFAULT_DRIVE/$MAVEN_FOLDER/bin"
+
+    mvn --version
+    echo "Maven was successfully installed on Windows."
 }
 
 # Confirm that the user has updated the config file. Stop the execution otherwise
@@ -72,7 +139,20 @@ echo
 
 # Confirm that the AWS CLI is installed. Ask the user for confirmation and install it otherwise
 echo "The AWS CLI is required to deploy the Sample Solution App. Checking if it is installed in the system ..."
-aws --version > /dev/null 2> /dev/null || install_aws_cli
+# Check if AWS CLI is installed
+if check_aws_cli; then
+    echo "AWS CLI is already installed. No action required."
+else
+    # Check the operating system and call the appropriate installation function
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        install_aws_cli_mac
+    elif [[ "$OSTYPE" == "msys" ]]; then
+        install_aws_cli_windows
+    else
+        echo "Unsupported operating system. The script supports macOS and Windows only."
+        exit 1
+    fi
+fi
 
 echo
 
@@ -89,29 +169,62 @@ echo
 # Language-specific pre-requisites
 
 # Get the programming language from the input arguments
-language=""
-while getopts 'l:' flag; do
-  case "${flag}" in
-    l) language="${OPTARG}";;
-  esac
-done
+language=$1
+
+if [ -z "${language}" ]; then
+  echo "A programming language is not selected. Aborting..."
+  exit 1
+fi
+
+# If it's a Java app, confirm that Maven is installed
+if [ "$language" == "java" ]; then
+  echo "Maven is required to deploy a Java Sample Solution App. Checking if it is installed in the system..."
+
+  if check_maven; then
+      echo "Maven is already installed. No action required."
+  else
+      # Check the operating system and call the appropriate installation function
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+          install_maven_mac
+      elif [[ "$OSTYPE" == "msys" ]]; then
+          install_maven_windows
+      else
+          echo "Unsupported operating system. The script supports macOS and Windows only."
+          exit 1
+      fi
+  fi
+fi
 
 # If it's a Python app, confirm that necessary Python packages are installed
 if [ "$language" == "python" ]; then
   echo "Certain Python packages are required to deploy a Python Sample Solution App. Checking if they are installed ..."
-  python3 -c "
-import pkg_resources
-import os
+  pythonCommand="import sys
+import subprocess
+from importlib.metadata import Distribution
 REQUIRED_PACKAGES = ['boto3', 'requests', 'setuptools']
+def install_package(package):
+    try:
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', package])
+        print(f'{package} has been installed successfully.')
+    except subprocess.CalledProcessError as e:
+        print(f'Error installing {package}.')
+
 for package in REQUIRED_PACKAGES:
   try:
-    dist = pkg_resources.get_distribution(package)
-    print('{} ({}) is installed'.format(dist.key, dist.version))
-  except pkg_resources.DistributionNotFound:
-    print('{} is NOT installed'.format(package))
-    print('Installing {} ...'.format(package))
-    os.system('python3 -m pip install {}'.format(package))
-  "
+        dist = Distribution.from_name(package)
+        print(f'{dist.metadata['Name']} ({dist.metadata['Version']}) is installed')
+  except ImportError:
+        print(f'{package} is NOT installed')
+        install_package(package)"
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    python3 -c "$pythonCommand"
+  elif [[ "$OSTYPE" == "msys" ]]; then
+    py -c "$pythonCommand"
+  else
+    echo "Unsupported operating system. The script supports macOS and Windows only."
+    exit 1
+  fi
 fi
 
 # If it's a CSharp app, install Amazon lambda tools or update if already installed


### PR DESCRIPTION
This change updates current bash deployment scripts for sample solutions in order to support **Windows Git Bash** users.
The change adapts the shared pre-requisites.sh and deploy-app.sh scripts to support installing Windows requirements needed for the deployment and packaging of the solutions.

You can now deploy any of the sample solutions on Windows by using Git Bash.