### PR TITLE
Fix wrong status code in error monitoring sample solution

### DIFF
--- a/use-cases/error-monitoring/README.md
+++ b/use-cases/error-monitoring/README.md
@@ -56,7 +56,12 @@ EmailId=user@domain.com
 Schedule=rate(1 minute)
 ```
 
-### 2. Configure Sample Solution App's IAM user
+### 2. Set region code and marketplace id
+You have to set region code and marketplace id that matches your account in the code. By default it is set to US.
+If you want to change the values go to [ErrorMonitoringHandler.java](https://github.com/amzn/selling-partner-api-samples/blob/main/use-cases/error-monitoring/code/java/src/main/java/lambda/ErrorMonitoringHandler.java#L28-L31) and enter the proper data.
+Available values can be found in [Constants.java](https://github.com/amzn/selling-partner-api-samples/blob/main/use-cases/error-monitoring/code/java/src/main/java/lambda/utils/Constants.java#L17-L33).
+
+### 3. Configure Sample Solution App's IAM user
 #### I. Create IAM policy
 In order to execute the deployment script, an IAM user with the appropriate permissions is needed.
 To create a new IAM policy with the required permissions, follow the steps below.
@@ -153,7 +158,7 @@ To create a new access key pair, follow the steps below. If you already have val
 9. Copy `Access key` and `Secret access key`. This is the only time that these keys can be viewed or downloaded, and you will need them while executing the deployment script
 10. Click **Done**
 
-### 3. Execute the deployment script
+### 4. Execute the deployment script
 The deployment script will create a Sample Solution App in the AWS cloud.
 To execute the deployment script, follow the steps below.
 1. Identify the deployment script for the programming language you want for your Sample Solution App.
@@ -164,7 +169,7 @@ To execute the deployment script, follow the steps below.
     1. Navigate to [CloudFormation console](https://console.aws.amazon.com/cloudformation/home)
     2. Wait for the stack named **sp-api-app-\<language\>-*random_suffix*** to show status `CREATE_COMPLETE`
 
-### 4. Test the sample solution
+### 5. Test the sample solution
 The deployment script creates a Sample Solution App in the AWS cloud.
 To test the sample solution, follow the steps below.
 1. Open the [AWS console](https://console.aws.amazon.com/)
@@ -198,7 +203,7 @@ EvaluationPeriods: 1
 Threshold: 5
 ```
 
-### 5. Clean-up
+### 6. Clean-up
 The deployment script creates a number of resources in the AWS cloud which you might want to delete after testing the solution.
 To clean up these resources, follow the steps below.
 1. Identify the clean-up script for the programming language of the Sample Solution App deployed to the AWS cloud.
@@ -206,7 +211,7 @@ To clean up these resources, follow the steps below.
 2. Execute the script from your terminal or Git Bash
     1. For example, to execute the Java clean-up script in a Unix-based system or using Git Bash, run `bash java-app-clean.sh`
 
-### 6. Troubleshooting
+### 7. Troubleshooting
 If you do not receive email notifications, follow the steps below to identify the root-cause and retry the workflow
 1. Open the [AWS console](https://console.aws.amazon.com/)
 2. Navigate to [Lambda console](https://console.aws.amazon.com/lambda/home)

--- a/use-cases/error-monitoring/code/java/src/main/java/lambda/ErrorMonitoringHandler.java
+++ b/use-cases/error-monitoring/code/java/src/main/java/lambda/ErrorMonitoringHandler.java
@@ -2,152 +2,131 @@ package lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
-import com.google.common.collect.Lists;
-
-import java.util.Map;
-
-import static lambda.utils.ApiUtils.*;
-import static lambda.utils.Constants.REFRESH_TOKEN_KEY_NAME;
-import static lambda.utils.Constants.REGION_CODE_KEY_NAME;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import io.swagger.client.ApiException;
 import io.swagger.client.ApiResponse;
 import io.swagger.client.api.CatalogApi;
+import io.swagger.client.api.ReportsApi;
+import io.swagger.client.api.SellersApi;
+import io.swagger.client.model.CatalogApi.Item;
 import io.swagger.client.model.CatalogApi.ItemSearchResults;
-import io.swagger.client.model.ListingsApi.Item;
 import io.swagger.client.model.ReportsApi.CreateReportResponse;
 import io.swagger.client.model.ReportsApi.CreateReportSpecification;
 import io.swagger.client.model.SellersApi.GetMarketplaceParticipationsResponse;
-
-import io.swagger.client.api.SellersApi;
-import io.swagger.client.api.ListingsApi;
-import io.swagger.client.api.ReportsApi;
-
-import lambda.utils.Constants;
 import org.threeten.bp.OffsetDateTime;
 
-
-import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
+import static lambda.utils.ApiUtils.*;
 import static lambda.utils.Constants.*;
 
 public class ErrorMonitoringHandler implements RequestHandler<Map<String, String>, String> {
 
+    // Make sure to use the region code that matches your account
+    private final String regionCode = NA_REGION_CODE;
+    // Make sure to use the marketplace id that matches your account
+    private final String marketplaceId = US_MARKETPLACE_ID;
+    private final String refreshToken = System.getenv(REFRESH_TOKEN);
 
     public String handleRequest(Map<String, String> input, Context context) {
         context.getLogger().log("Input: " + input);
 
-        String regionCode = NA_REGION_CODE;
-        String refreshToken = System.getenv("REFRESH_TOKEN");
+        triggerSuccessResponse(context);
 
-        //Multiple try catch blocks to test different 4xx errors
+        //Test different 4xx errors
+        triggerBadRequestResponse(context);
+        triggerNotFoundResponse(context);
+        triggerTooManyRequestsResponse(context);
 
+        return "Success!";
+    }
+
+    private void triggerBadRequestResponse(Context context) {
         try {
-            // Test 400 Error
             CatalogApi catalogApi = catalogItemsApi(regionCode, refreshToken);
 
             String identifiersType = "ASINS";
-            List<String> includedData = Arrays.asList("relationships", "attributes", "dimensions", "identifiers", "images", "productTypes", "salesRanks", "summaries");
-            List<String> identifiers = Arrays.asList(TEST_IDENTIFIER);
-            List<String> marketplaceIds = Arrays.asList(US_MARKETPLACE_ID);
+            List<String> identifiers = singletonList(TEST_IDENTIFIER);
+            List<String> marketplaceIds = singletonList(marketplaceId);
 
-            ApiResponse<ItemSearchResults> httpResult = catalogApi.searchCatalogItemsWithHttpInfo(marketplaceIds, identifiers, identifiersType, includedData, null, null, null, null, null, null, null, null);
-            context.getLogger().log("Status Code: " + httpResult.getStatusCode());
-            context.getLogger().log("Headers: " + httpResult.getHeaders());
-            context.getLogger().log("Data: " + httpResult.getData());
-
+            ApiResponse<ItemSearchResults> httpResult = catalogApi.searchCatalogItemsWithHttpInfo(marketplaceIds, identifiers, identifiersType, null, null, null, null, null, null, null, null, null);
+            logSuccessResponse(context, httpResult);
 
         } catch (ApiException e) {
-
-            context.getLogger().log("Status Code: " + e.getCode());
-            JsonObject errorResponse = new Gson().fromJson(e.getResponseBody(), JsonObject.class);
-            context.getLogger().log("Body: " + errorResponse);
+            logApiException(context, e);
         } catch (Exception e) {
-
             context.getLogger().log(String.valueOf(e));
         }
+    }
 
+    private void triggerSuccessResponse(Context context) {
         try {
-            //Test 200 call
             SellersApi sellersApi = sellersApi(regionCode, refreshToken);
 
             ApiResponse<GetMarketplaceParticipationsResponse> httpResult = sellersApi.getMarketplaceParticipationsWithHttpInfo();
-
-            context.getLogger().log("Status Code: " + httpResult.getStatusCode());
-            context.getLogger().log("Headers: " + httpResult.getHeaders());
-            context.getLogger().log("Data: " + httpResult.getData());
-
+            logSuccessResponse(context, httpResult);
 
         } catch (ApiException e) {
-
-            context.getLogger().log("Message: " + e.getMessage());
-            context.getLogger().log("Status Code: " + e.getCode());
-            JsonObject errorResponse = new Gson().fromJson(e.getResponseBody(), JsonObject.class);
-            context.getLogger().log("Body: " + errorResponse);
+            logApiException(context, e);
         } catch (Exception e) {
-
             context.getLogger().log(String.valueOf(e));
         }
+    }
 
-
-
+    private void triggerNotFoundResponse(Context context) {
         try {
-            //Test 404 Error
-            ListingsApi listingsApi = listingsApi(regionCode, refreshToken);
+            CatalogApi catalogApi = catalogItemsApi(regionCode, refreshToken);
 
-            String sellerId = SELLER_ID;
-            String sku = SKU;
-            List<String> includedData = Arrays.asList("issues", "attributes", "offers", "fulfillmentAvailability", "procurement", "summaries");
-            List<String> marketplaceIds = Arrays.asList(US_MARKETPLACE_ID);
-
-            ApiResponse<Item> httpResult = listingsApi.getListingsItemWithHttpInfo(sellerId, sku, marketplaceIds, null, includedData);
-
-            context.getLogger().log("Status Code: " + httpResult.getStatusCode());
-            context.getLogger().log("Headers: " + httpResult.getHeaders());
-            context.getLogger().log("Data: " + httpResult.getData());
+            ApiResponse<Item> httpResult = catalogApi.getCatalogItemWithHttpInfo(
+                    INVALID_ASIN,
+                    singletonList(marketplaceId),
+                    null,
+                    null
+            );
+            logSuccessResponse(context, httpResult);
 
         } catch (ApiException e) {
-
-            context.getLogger().log("Message: " + e.getMessage());
-            context.getLogger().log("Status Code: " + e.getCode());
-            JsonObject errorResponse = new Gson().fromJson(e.getResponseBody(), JsonObject.class);
-            context.getLogger().log("Body: " + errorResponse);
+            logApiException(context, e);
         } catch (Exception e) {
-
             context.getLogger().log(String.valueOf(e));
         }
+    }
 
+    private void triggerTooManyRequestsResponse(Context context) {
         try {
-            //Test 429 Error
             ReportsApi reportsApi = reportsApi(regionCode, refreshToken);
 
             for (int i = 0; i < 20; i++) {
                 context.getLogger().log(String.valueOf(i));
                 CreateReportSpecification body = new CreateReportSpecification()
                         .reportType(REPORT_TYPE) // Example report type
-                        .marketplaceIds(Arrays.asList(US_MARKETPLACE_ID)) // Example marketplace ID
+                        .marketplaceIds(singletonList(marketplaceId)) // Example marketplace ID
                         .dataStartTime(OffsetDateTime.parse("2024-05-01T00:00:00Z")) // Example start time
                         .dataEndTime(OffsetDateTime.parse("2024-05-30T23:59:59Z")); // Example end time
                 ApiResponse<CreateReportResponse> httpResult = reportsApi.createReportWithHttpInfo(body);
 
-                context.getLogger().log("Status Code: " + httpResult.getStatusCode());
-                context.getLogger().log("Headers: " + httpResult.getHeaders());
-                context.getLogger().log("Data: " + httpResult.getData());
-
+                logSuccessResponse(context, httpResult);
             }
         } catch (ApiException e) {
-
-            context.getLogger().log("Message: " + e.getMessage());
-            context.getLogger().log("Status Code: " + e.getCode());
-            JsonObject errorResponse = new Gson().fromJson(e.getResponseBody(), JsonObject.class);
-            context.getLogger().log("Body: " + errorResponse);
+            logApiException(context, e);
         } catch (Exception e) {
-
-            System.out.println(e);
+            context.getLogger().log(String.valueOf(e));
         }
-
-        return "Success!";
     }
 
+    private <T> void logSuccessResponse(Context context, ApiResponse<T> response) {
+        context.getLogger().log("Status Code: " + response.getStatusCode());
+        context.getLogger().log("Headers: " + response.getHeaders());
+        context.getLogger().log("Data: " + response.getData());
+    }
+
+    private void logApiException(Context context, ApiException e) {
+        context.getLogger().log("Message: " + e.getMessage());
+        context.getLogger().log("Status Code: " + e.getCode());
+        JsonObject errorResponse = new Gson().fromJson(e.getResponseBody(), JsonObject.class);
+        context.getLogger().log("Body: " + errorResponse);
+    }
 }

--- a/use-cases/error-monitoring/code/java/src/main/java/lambda/utils/Constants.java
+++ b/use-cases/error-monitoring/code/java/src/main/java/lambda/utils/Constants.java
@@ -14,13 +14,27 @@ public class Constants {
     public static final String FE_REGION_CODE = "FE";
     public static final String SP_API_FE_ENDPOINT = "https://sellingpartnerapi-fe.amazon.com";
 
-    public static final String SELLER_ID = "SellerId";
-    public static final String SKU = "testSKU";
-    public static final String REPORT_TYPE = "GET_MERCHANT_LISTINGS_ALL_DATA";
-
-    public static final String TEST_IDENTIFIER = "B0D1GN282B";
+    // North America marketplaces
     public static final String US_MARKETPLACE_ID = "ATVPDKIKX0DER";
+    public static final String CA_MARKETPLACE_ID = "A2EUQ1WTGCTBG2";
+    public static final String MX_MARKETPLACE_ID = "A1AM78C64UM0Y8";
+    public static final String BR_MARKETPLACE_ID = "A2Q3Y263D00KWC";
 
+    // Europe marketplaces
+    public static final String ES_MARKETPLACE_ID = "A1RKKUPIHCS9HS";
+    public static final String UK_MARKETPLACE_ID = "A1F83G8C2ARO7P";
+    public static final String FR_MARKETPLACE_ID = "A13V1IB3VIYZZH";
+    public static final String DE_MARKETPLACE_ID = "A1PA6795UKMFR9";
+    public static final String IT_MARKETPLACE_ID = "APJ6JRA9NG5V4";
+
+    // Far East marketplaces
+    public static final String SG_MARKETPLACE_ID = "A19VAU5U5O7RUS";
+    public static final String AU_MARKETPLACE_ID = "A39IBJ37TRP1C6";
+    public static final String JP_MARKETPLACE_ID = "A1VC38T7YXB528";
+
+    public static final String REPORT_TYPE = "GET_MERCHANT_LISTINGS_ALL_DATA";
+    public static final String TEST_IDENTIFIER = "B0D1GN282B";
+    public static final String INVALID_ASIN = "0000000001";
 
     public static final Map<String, String> VALID_SP_API_REGION_CONFIG = ImmutableMap.of(
             NA_REGION_CODE, SP_API_NA_ENDPOINT,
@@ -32,8 +46,5 @@ public class Constants {
 
     //Lambda Environment Variables
     public static final String SP_API_APP_CREDENTIALS_SECRET_ARN_ENV_VARIABLE = "SP_API_APP_CREDENTIALS_SECRET_ARN";
-
-    //Generic Lambda Input Parameters
-    public static final String REGION_CODE_KEY_NAME = "RegionCode";
-    public static final String REFRESH_TOKEN_KEY_NAME = "RefreshToken";
+    public static final String REFRESH_TOKEN = "REFRESH_TOKEN";
 }


### PR DESCRIPTION
While migrating the error monitoring sample solution to AWS CDK I figured out that one of the requests in the Lambda function is not returning the expected http status code (instead of 404 the call returned 400). This is fixed with this PR.

Also changed in this PR:
- Add a section to the README to set region code and marketplace id before deploying (otherwise the solution doesn't really work for non US accounts)
- Remove duplicated code from ErrorMonitoringHandler
- Add marketplace ids for multiple regions to the Constants file to make switching them as easy as possible
- Some boyscouting (optimize imports, fix warnings etc.)