### PR TITLE
Update the package-json to use local dependency to avoid dependency injection attack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "selling-partner-api-samples",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/use-cases/amazon-data-kiosk-mcp-server/package-lock.json
+++ b/use-cases/amazon-data-kiosk-mcp-server/package-lock.json
@@ -11,10 +11,6 @@
         "packages/*"
       ]
     },
-    "node_modules/@amazon-data-kiosk/common": {
-      "resolved": "packages/common",
-      "link": true
-    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.10.2.tgz",
@@ -117,6 +113,10 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/common": {
+      "resolved": "packages/common",
+      "link": true
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -415,6 +415,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -673,12 +678,26 @@
         "wrappy": "1"
       }
     },
+    "node_modules/os": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.2.tgz",
+      "integrity": "sha512-ZoXJkvAnljwvc56MbvhtKVWmSkzV712k42Is2mA0+0KTSRakq5XXuXpjZjgAt9ctzl51ojhQWakQQpmOvXWfjQ=="
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
       }
     },
     "node_modules/path-key": {
@@ -703,6 +722,14 @@
       "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -975,6 +1002,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1027,10 +1067,12 @@
       }
     },
     "packages/common": {
-      "name": "@amazon-data-kiosk/common",
       "version": "1.0.0",
       "dependencies": {
+        "fs": "^0.0.1-security",
         "node-fetch": "^3.3.2",
+        "os": "^0.1.2",
+        "path": "^0.12.7",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -1042,8 +1084,8 @@
       "name": "amazon-seller-analytics-mcp-server",
       "version": "1.0.0",
       "dependencies": {
-        "@amazon-data-kiosk/common": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.10.2",
+        "common": "^1.0.0",
         "zod": "^3.22.4"
       },
       "bin": {
@@ -1058,8 +1100,8 @@
       "name": "amazon-vendor-analytics-mcp-server",
       "version": "1.0.0",
       "dependencies": {
-        "@amazon-data-kiosk/common": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.10.2",
+        "common": "^1.0.0",
         "zod": "^3.22.4"
       },
       "bin": {
@@ -1072,15 +1114,6 @@
     }
   },
   "dependencies": {
-    "@amazon-data-kiosk/common": {
-      "version": "file:packages/common",
-      "requires": {
-        "@types/node": "^20.11.0",
-        "node-fetch": "^3.3.2",
-        "typescript": "^5.3.3",
-        "zod": "^3.22.4"
-      }
-    },
     "@modelcontextprotocol/sdk": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.10.2.tgz",
@@ -1119,9 +1152,9 @@
     "amazon-seller-analytics-mcp-server": {
       "version": "file:packages/seller-server",
       "requires": {
-        "@amazon-data-kiosk/common": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.10.2",
         "@types/node": "^20.11.0",
+        "common": "^1.0.0",
         "typescript": "^5.3.3",
         "zod": "^3.22.4"
       }
@@ -1129,9 +1162,9 @@
     "amazon-vendor-analytics-mcp-server": {
       "version": "file:packages/vendor-server",
       "requires": {
-        "@amazon-data-kiosk/common": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.10.2",
         "@types/node": "^20.11.0",
+        "common": "^1.0.0",
         "typescript": "^5.3.3",
         "zod": "^3.22.4"
       }
@@ -1173,6 +1206,18 @@
       "requires": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
+      }
+    },
+    "common": {
+      "version": "file:packages/common",
+      "requires": {
+        "@types/node": "^20.11.0",
+        "fs": "^0.0.1-security",
+        "node-fetch": "^3.3.2",
+        "os": "^0.1.2",
+        "path": "^0.12.7",
+        "typescript": "^5.3.3",
+        "zod": "^3.22.4"
       }
     },
     "content-disposition": {
@@ -1376,6 +1421,11 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
     },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
+    },
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1544,10 +1594,24 @@
         "wrappy": "1"
       }
     },
+    "os": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.2.tgz",
+      "integrity": "sha512-ZoXJkvAnljwvc56MbvhtKVWmSkzV712k42Is2mA0+0KTSRakq5XXuXpjZjgAt9ctzl51ojhQWakQQpmOvXWfjQ=="
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
     },
     "path-key": {
       "version": "3.1.1",
@@ -1563,6 +1627,11 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
       "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ=="
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -1746,6 +1815,21 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "requires": {
+        "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+        }
+      }
     },
     "vary": {
       "version": "1.1.2",

--- a/use-cases/amazon-data-kiosk-mcp-server/packages/common/package.json
+++ b/use-cases/amazon-data-kiosk-mcp-server/packages/common/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amazon-data-kiosk/common",
+  "name": "common",
   "version": "1.0.0",
   "description": "Common utilities for Amazon Data Kiosk MCP servers",
   "type": "module",

--- a/use-cases/amazon-data-kiosk-mcp-server/packages/seller-server/package.json
+++ b/use-cases/amazon-data-kiosk-mcp-server/packages/seller-server/package.json
@@ -13,7 +13,7 @@
     "dev": "tsc -w"
   },
   "dependencies": {
-    "@amazon-data-kiosk/common": "^1.0.0",
+    "common": "^1.0.0",
     "@modelcontextprotocol/sdk": "^1.10.2",
     "zod": "^3.22.4"
   },

--- a/use-cases/amazon-data-kiosk-mcp-server/packages/seller-server/src/api/economics.ts
+++ b/use-cases/amazon-data-kiosk-mcp-server/packages/seller-server/src/api/economics.ts
@@ -1,6 +1,6 @@
 // src/api/economics.ts
-import { makeApiRequest } from '@amazon-data-kiosk/common';
-import { API_VERSION, SCHEMA_NAMES } from '@amazon-data-kiosk/common';
+import { makeApiRequest } from 'common';
+import { API_VERSION, SCHEMA_NAMES } from 'common';
 
 // Economics Query Types
 export type DateGranularity = 'DAY' | 'WEEK' | 'MONTH' | 'RANGE';

--- a/use-cases/amazon-data-kiosk-mcp-server/packages/seller-server/src/api/salesAndTraffic.ts
+++ b/use-cases/amazon-data-kiosk-mcp-server/packages/seller-server/src/api/salesAndTraffic.ts
@@ -1,6 +1,6 @@
 // src/api/salesAndTraffic.ts
-import { makeApiRequest } from '@amazon-data-kiosk/common';
-import { API_VERSION, SCHEMA_NAMES } from '@amazon-data-kiosk/common';
+import { makeApiRequest } from 'common';
+import { API_VERSION, SCHEMA_NAMES } from 'common';
 
 // Sales and Traffic Query Types
 export type DateGranularity = 'DAY' | 'WEEK' | 'MONTH';

--- a/use-cases/amazon-data-kiosk-mcp-server/packages/seller-server/src/index.ts
+++ b/use-cases/amazon-data-kiosk-mcp-server/packages/seller-server/src/index.ts
@@ -4,8 +4,8 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerSalesTools } from "./tools/salesTools.js";
 import { registerEconomicsTools } from "./tools/economicsTools.js";
-import { registerGeneralTools } from "@amazon-data-kiosk/common";
-import { checkEnvironment } from "@amazon-data-kiosk/common";
+import { registerGeneralTools } from "common";
+import { checkEnvironment } from "common";
 
 // Create server instance with seller-specific name
 const server = new McpServer({

--- a/use-cases/amazon-data-kiosk-mcp-server/packages/seller-server/src/tools/economicsTools.ts
+++ b/use-cases/amazon-data-kiosk-mcp-server/packages/seller-server/src/tools/economicsTools.ts
@@ -2,8 +2,8 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { buildEconomicsQuery, buildEconomicsPreviewQuery } from "../api/economics.js";
-import { formatErrorMessage } from "@amazon-data-kiosk/common";
-import { MARKETPLACES } from "@amazon-data-kiosk/common";
+import { formatErrorMessage } from "common";
+import { MARKETPLACES } from "common";
 
 /**
  * Register economics tools with the MCP server

--- a/use-cases/amazon-data-kiosk-mcp-server/packages/seller-server/src/tools/salesTools.ts
+++ b/use-cases/amazon-data-kiosk-mcp-server/packages/seller-server/src/tools/salesTools.ts
@@ -2,8 +2,8 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { buildSalesAndTrafficQuery } from "../api/salesAndTraffic.js";
-import { formatErrorMessage } from "@amazon-data-kiosk/common";
-import { MARKETPLACES } from "@amazon-data-kiosk/common";
+import { formatErrorMessage } from "common";
+import { MARKETPLACES } from "common";
 
 /**
  * Register sales and traffic tools with the MCP server

--- a/use-cases/amazon-data-kiosk-mcp-server/packages/vendor-server/package.json
+++ b/use-cases/amazon-data-kiosk-mcp-server/packages/vendor-server/package.json
@@ -13,7 +13,7 @@
     "dev": "tsc -w"
   },
   "dependencies": {
-    "@amazon-data-kiosk/common": "^1.0.0",
+    "common": "^1.0.0",
     "@modelcontextprotocol/sdk": "^1.10.2",
     "zod": "^3.22.4"
   },

--- a/use-cases/amazon-data-kiosk-mcp-server/packages/vendor-server/src/api/vendorAnalytics.ts
+++ b/use-cases/amazon-data-kiosk-mcp-server/packages/vendor-server/src/api/vendorAnalytics.ts
@@ -1,6 +1,6 @@
 // src/api/vendorAnalytics.ts
-import { makeApiRequest } from '@amazon-data-kiosk/common';
-import { API_VERSION } from '@amazon-data-kiosk/common';
+import { makeApiRequest } from 'common';
+import { API_VERSION } from 'common';
 
 // Vendor Analytics Query Types
 export type ViewType = 'sourcing' | 'manufacturing';

--- a/use-cases/amazon-data-kiosk-mcp-server/packages/vendor-server/src/index.ts
+++ b/use-cases/amazon-data-kiosk-mcp-server/packages/vendor-server/src/index.ts
@@ -2,7 +2,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerVendorTools } from "./tools/vendorTools.js";
-import { checkEnvironment, registerGeneralTools } from "@amazon-data-kiosk/common";
+import { checkEnvironment, registerGeneralTools } from "common";
 
 // Create server instance with vendor-specific name
 const server = new McpServer({

--- a/use-cases/amazon-data-kiosk-mcp-server/packages/vendor-server/src/tools/vendorTools.ts
+++ b/use-cases/amazon-data-kiosk-mcp-server/packages/vendor-server/src/tools/vendorTools.ts
@@ -2,7 +2,7 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { buildVendorAnalyticsQuery } from "../api/vendorAnalytics.js";
-import { formatErrorMessage } from "@amazon-data-kiosk/common";
+import { formatErrorMessage } from "common";
 
 
 /**


### PR DESCRIPTION
update the package-json to use local dependency to avoid dependency injection attack
```
   "node_modules/common": {
      "resolved": "packages/common",
      "link": true
    }
```

This block in a `package-lock.json` file represents a local package dependency that's been linked using npm's workspace or linking functionality.

Here's what each part means:

- **`"node_modules/common"`**: This is the path where the package appears in your `node_modules` directory
- **`"resolved": "packages/common"`**: This indicates the actual location of the package source code is in the `packages/common` directory (relative to your project root)
- **`"link": true"`**: This flag tells npm that this is a symbolic link rather than a downloaded package from the npm registry

This setup is commonly used in:

1. **Monorepos** - where you have multiple related packages in a single repository (like using Lerna, Nx, or npm workspaces)
2. **Local development** - when you're developing a package locally and want to test it in another project without publishing it
3. **Yarn/npm workspaces** - where packages within the workspace are automatically linked to each other

Instead of npm downloading and installing a separate copy of the "common" package from the registry, it creates a symbolic link from `node_modules/common` to your local `packages/common` directory. This means changes to the source code in `packages/common` are immediately reflected wherever it's used, without needing to reinstall or republish the package.