### PR TITLE
Add Notifications and Solicitations Code Recipes

### DIFF
--- a/code-recipes/README.md
+++ b/code-recipes/README.md
@@ -4,7 +4,7 @@ Code recipes provides easy to read sample code for common use cases of Amazon Se
 
 ## Use Cases
 | API | Use Case | Java | Python | PHP | Reference |
-| --- | -------- | ---- | ------ | --- | --------- |
+| --- | --- | --- | --- | --- | --- |
 | AWD | Inbound Shipment Creation | [Link](java/src/main/java/awd/InboundOrderCreationRecipe.java) | - | [Link](php/src/awd/InboundOrderCreationRecipe.php) | [Docs](https://developer-docs.amazon.com/sp-api/docs/amazon-warehousing-and-distribution-api) |
 | A+ Content API | Submit an Image to A+ Content | [Link](java/src/main/java/aplus/UploadImageForResourceRecipe.java) | - | [Link](php/src/aplus/UploadImageForResourceRecipe.php) | [Docs](https://developer-docs.amazon.com/sp-api/docs/a-plus-content-api-use-case-guide) |
 | Messaging API | Submit an Invoice to Buyer | [Link](java/src/main/java/messaging/SendInvoiceToBuyerRecipe.java) | - | [Link](php/src/messaging/SendInvoiceToBuyerRecipe.php) | [Docs](https://developer-docs.amazon.com/sp-api/docs/messaging-api) |
@@ -19,3 +19,6 @@ Code recipes provides easy to read sample code for common use cases of Amazon Se
 | Easy Ship | Submit Feed Request | [Link](java/src/main/java/easyship/SubmitFeedRequestRecipe.java) | - | [Link](php/src/easyship/SubmitFeedRequestRecipe.php) | [Docs](https://developer-docs.amazon.com/sp-api/docs/feeds-api-v2021-06-30-reference) |
 | Easy Ship | Get Feed Document | [Link](java/src/main/java/easyship/GetFeedDocumentRecipe.java) | - | [Link](php/src/easyship/GetFeedDocumentRecipe.php) | [Docs](https://developer-docs.amazon.com/sp-api/docs/feeds-api-v2021-06-30-reference) |
 | Easy Ship | Download Shipping Label | [Link](java/src/main/java/easyship/DownloadShippingLabelRecipe.java) | - | [Link](php/src/easyship/DownloadShippingLabelRecipe.php) | [Docs](https://developer-docs.amazon.com/sp-api/docs/easy-ship-api) |
+| Notifications | Create Destination | [Link](code-recipes/java/src/test/java/notifications/CreateDestinationRecipe.java) | - | - | [Docs](https://developer-docs.amazon.com/sp-api/docs/notifications-api) |
+| Notifications | Create Subscription | [Link](code-recipes/java/src/test/java/notifications/CreateSubscriptionRecipe.java) | - | - | [Docs](https://developer-docs.amazon.com/sp-api/docs/notifications-api) |
+| Solicitations | Solicit Product Review | [Link](code-recipes/java/src/main/java/solicitations/SolicitProductReviewRecipe.java) | - | - | [Docs](https://developer-docs.amazon.com/sp-api/docs/solicitations-api) |

--- a/code-recipes/java/src/main/java/notifications/CreateDestinationRecipe.java
+++ b/code-recipes/java/src/main/java/notifications/CreateDestinationRecipe.java
@@ -1,0 +1,105 @@
+package notifications;
+
+import software.amazon.spapi.ApiException;
+import software.amazon.spapi.api.notifications.v1.NotificationsApi;
+import software.amazon.spapi.models.notifications.v1.*;
+import util.Recipe;
+import util.Constants;
+
+import com.amazon.SellingPartnerAPIAA.LWAException;
+
+/**
+ * Code Recipe to create a notification destination
+ * Steps:
+ * 1. Create destination for SQS queue or EventBridge
+ * 2. Handle destination already exists (409 conflict)
+ */
+public class CreateDestinationRecipe extends Recipe {
+
+    private static final String SQS_QUEUE_ARN = "arn:aws:sqs:us-east-1:123456789012:sqs_queue_example"; // Set to SQS ARN or null
+    private static final String EVENTBRIDGE_NAME = "example_event_bridge"; // Set to EventBridge name or null
+    private static final String EVENTBRIDGE_REGION = "us-east-1";
+    private static final String EVENTBRIDGE_ACCOUNT_ID = "123456789012";
+    
+    private NotificationsApi notificationsApi;
+
+    @Override
+    protected void start() {
+        initializeNotificationsApi();
+        String destinationId = createDestination();
+        System.out.println("✅ Destination Id: " + destinationId);
+    }
+
+    private void initializeNotificationsApi() {
+        notificationsApi = new NotificationsApi.Builder()
+                .lwaAuthorizationCredentials(lwaCredentials)
+                .endpoint(Constants.BACKEND_URL)
+                .disableAccessTokenCache()
+                .build();
+        System.out.println("Notifications API client initialized");
+    }
+
+    private String createDestination() {
+        if (SQS_QUEUE_ARN == null && EVENTBRIDGE_NAME == null) {
+            throw new RuntimeException("Either SQS_QUEUE_ARN or EVENTBRIDGE_NAME must be set");
+        }
+        
+        DestinationResourceSpecification resourceSpec = new DestinationResourceSpecification();
+        
+        if (SQS_QUEUE_ARN != null) {
+            SqsResource sqsResource = new SqsResource();
+            sqsResource.setArn(SQS_QUEUE_ARN);
+            resourceSpec.setSqs(sqsResource);
+        }
+        
+        if (EVENTBRIDGE_NAME != null) {
+            EventBridgeResourceSpecification eventBridge = new EventBridgeResourceSpecification();
+            eventBridge.setRegion(EVENTBRIDGE_REGION);
+            eventBridge.setAccountId(EVENTBRIDGE_ACCOUNT_ID);
+            resourceSpec.setEventBridge(eventBridge);
+        }
+        
+        CreateDestinationRequest request = new CreateDestinationRequest();
+        request.setName("sp-api-destination");
+        request.setResourceSpecification(resourceSpec);
+
+        try {
+            CreateDestinationResponse response = notificationsApi.createDestination(request);
+            String destId = response.getPayload().getDestinationId();
+            System.out.println("✅ Destination created - Destination Id: " + destId);
+            return destId;
+        } catch (ApiException e) {
+            if (e.getCode() == 409) {
+                System.out.println("⚠️ Destination already exists, retrieving existing destination");
+                return getExistingDestination();
+            }
+            throw new RuntimeException("Failed to create destination", e);
+        } catch (LWAException e) {
+            throw new RuntimeException("Failed to create destination", e);
+        }
+    }
+
+    private String getExistingDestination() {
+        try {
+            GetDestinationsResponse response = notificationsApi.getDestinations();
+            for (Destination destination : response.getPayload()) {
+                boolean sqsMatches = SQS_QUEUE_ARN == null || 
+                    (destination.getResource().getSqs() != null && 
+                     SQS_QUEUE_ARN.equals(destination.getResource().getSqs().getArn()));
+                
+                boolean eventBridgeMatches = EVENTBRIDGE_NAME == null || 
+                    (destination.getResource().getEventBridge() != null &&
+                     EVENTBRIDGE_ACCOUNT_ID.equals(destination.getResource().getEventBridge().getAccountId()));
+                
+                if (sqsMatches && eventBridgeMatches) {
+                    String destId = destination.getDestinationId();
+                    System.out.println("✅ Found existing destination - Destination Id: " + destId);
+                    return destId;
+                }
+            }
+            throw new RuntimeException("Destination not found");
+        } catch (ApiException | LWAException e) {
+            throw new RuntimeException("Failed to get destinations", e);
+        }
+    }
+}

--- a/code-recipes/java/src/main/java/notifications/CreateSubscriptionRecipe.java
+++ b/code-recipes/java/src/main/java/notifications/CreateSubscriptionRecipe.java
@@ -1,0 +1,71 @@
+package notifications;
+
+import software.amazon.spapi.ApiException;
+import software.amazon.spapi.api.notifications.v1.NotificationsApi;
+import software.amazon.spapi.models.notifications.v1.*;
+import util.Recipe;
+import util.Constants;
+
+import com.amazon.SellingPartnerAPIAA.LWAException;
+
+/**
+ * Code Recipe to create a notification subscription
+ * Steps:
+ * 1. Create subscription for notification type
+ * 2. Handle subscription already exists (409 conflict)
+ */
+public class CreateSubscriptionRecipe extends Recipe {
+
+    private static final String NOTIFICATION_TYPE = "ORDER_CHANGE";
+    private static final String DESTINATION_ID = "dest-12345-abcde-67890";
+    
+    private NotificationsApi notificationsApi;
+
+    @Override
+    protected void start() {
+        initializeNotificationsApi();
+        String subscriptionId = createSubscription();
+        System.out.println("✅ Subscription Id: " + subscriptionId);
+    }
+
+    private void initializeNotificationsApi() {
+        notificationsApi = new NotificationsApi.Builder()
+                .lwaAuthorizationCredentials(lwaCredentials)
+                .endpoint(Constants.BACKEND_URL)
+                .disableAccessTokenCache()
+                .build();
+        System.out.println("Notifications API client initialized");
+    }
+
+    private String createSubscription() {
+        CreateSubscriptionRequest request = new CreateSubscriptionRequest();
+        request.setPayloadVersion("1.0");
+        request.setDestinationId(DESTINATION_ID);
+
+        try {
+            CreateSubscriptionResponse response = notificationsApi.createSubscription(request, NOTIFICATION_TYPE);
+            String subId = response.getPayload().getSubscriptionId();
+            System.out.println("✅ Subscription created - Subscription Id: " + subId);
+            return subId;
+        } catch (ApiException e) {
+            if (e.getCode() == 409) {
+                System.out.println("⚠️ Subscription already exists, retrieving existing subscription");
+                return getExistingSubscription();
+            }
+            throw new RuntimeException("Failed to create subscription", e);
+        } catch (LWAException e) {
+            throw new RuntimeException("Failed to create subscription", e);
+        }
+    }
+
+    private String getExistingSubscription() {
+        try {
+            GetSubscriptionResponse response = notificationsApi.getSubscription(NOTIFICATION_TYPE, null);
+            String subId = response.getPayload().getSubscriptionId();
+            System.out.println("✅ Found existing subscription - Subscription Id: " + subId);
+            return subId;
+        } catch (ApiException | LWAException e) {
+            throw new RuntimeException("Failed to get subscription", e);
+        }
+    }
+}

--- a/code-recipes/java/src/main/java/solicitations/SolicitProductReviewRecipe.java
+++ b/code-recipes/java/src/main/java/solicitations/SolicitProductReviewRecipe.java
@@ -1,0 +1,168 @@
+package solicitations;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import software.amazon.spapi.ApiException;
+import software.amazon.spapi.api.orders.v0.OrdersV0Api;
+import software.amazon.spapi.api.solicitations.v1.SolicitationsApi;
+import software.amazon.spapi.models.orders.v0.GetOrderResponse;
+import software.amazon.spapi.models.orders.v0.Order;
+import software.amazon.spapi.models.solicitations.v1.CreateProductReviewAndSellerFeedbackSolicitationResponse;
+import software.amazon.spapi.models.solicitations.v1.GetSolicitationActionsForOrderResponse;
+import software.amazon.spapi.models.solicitations.v1.LinkObject;
+import util.Recipe;
+import util.Constants;
+
+import com.amazon.SellingPartnerAPIAA.LWAException;
+import java.io.File;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * Code Recipe to solicit product reviews after order shipment
+ * Steps:
+ * 1. Parse ORDER_CHANGE notification
+ * 2. Validate OrderStatus is Shipped
+ * 3. Get order details and check delivery dates
+ * 4. Store key identifiers
+ * 5. Check if product review can be solicited
+ * 6. Solicit product review
+ * 
+ * NOTE: If you don't have a notification subscription, please refer to the notifications code-recipes to learn how to create one.
+ */
+
+public class SolicitProductReviewRecipe extends Recipe {
+
+    private OrdersV0Api ordersApi;
+    private SolicitationsApi solicitationsApi;
+    private String notificationFilePath;
+
+    @Override
+    protected void start() {
+        notificationFilePath = "../test/resources/notifications/ORDER_CHANGE/shipped.json";
+        java.util.Map<String, Object> notification = parseNotification();
+        if (validateOrderStatus(notification)) {
+            java.util.Map<String, Object> payload = (java.util.Map<String, Object>) notification.get("Payload");
+            java.util.Map<String, Object> orderChange = (java.util.Map<String, Object>) payload.get("OrderChangeNotification");
+            String amazonOrderId = (String) orderChange.get("AmazonOrderId");
+            java.util.Map<String, Object> summary = (java.util.Map<String, Object>) orderChange.get("Summary");
+            String marketplaceId = (String) summary.get("MarketplaceId");
+            
+            initializeOrdersApi();
+            Order order = getOrderDetails(amazonOrderId);
+            
+            if (checkDeliveryDates(order)) {
+                storeKeyIdentifiers(amazonOrderId, marketplaceId);
+                initializeSolicitationsApi();
+                if (canSolicitReview(amazonOrderId, List.of(marketplaceId))) {
+                    solicitProductReview(amazonOrderId, List.of(marketplaceId));
+                } else {
+                    System.out.println("❌ Cannot solicit review for this order");
+                }
+            } else {
+                System.out.println("❌ Order is outside the valid solicitation timeframe");
+            }
+        } else {
+            System.out.println("❌ Order status is not Shipped");
+        }
+    }
+
+    private java.util.Map<String, Object> parseNotification() {
+        try {
+            return JSON.std.mapFrom(new File(notificationFilePath));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to parse notification", e);
+        }
+    }
+
+    private boolean validateOrderStatus(java.util.Map<String, Object> notification) {
+        java.util.Map<String, Object> payload = (java.util.Map<String, Object>) notification.get("Payload");
+        java.util.Map<String, Object> orderChange = (java.util.Map<String, Object>) payload.get("OrderChangeNotification");
+        java.util.Map<String, Object> summary = (java.util.Map<String, Object>) orderChange.get("Summary");
+        String orderStatus = (String) summary.get("OrderStatus");
+        boolean isShipped = "Shipped".equals(orderStatus);
+        System.out.println(isShipped ? "✅ Order status is Shipped" : "Order status: " + orderStatus);
+        return isShipped;
+    }
+
+    private void initializeOrdersApi() {
+        ordersApi = new OrdersV0Api.Builder()
+                .lwaAuthorizationCredentials(lwaCredentials)
+                .endpoint(Constants.BACKEND_URL)
+                .disableAccessTokenCache()
+                .build();
+        System.out.println("Orders API client initialized");
+    }
+
+    private Order getOrderDetails(String amazonOrderId) {
+        try {
+            GetOrderResponse response = ordersApi.getOrder(amazonOrderId);
+            System.out.println("✅ Retrieved order details");
+            return response.getPayload();
+        } catch (ApiException | LWAException e) {
+            throw new RuntimeException("Failed to get order details", e);
+        }
+    }
+
+    private boolean checkDeliveryDates(Order order) {
+        if (order.getEarliestDeliveryDate() == null || order.getLatestDeliveryDate() == null) {
+            System.out.println("❌ Delivery dates not available");
+            return false;
+        }
+        
+        OffsetDateTime earliestDelivery = OffsetDateTime.parse(order.getEarliestDeliveryDate());
+        OffsetDateTime latestDelivery = OffsetDateTime.parse(order.getLatestDeliveryDate());
+        OffsetDateTime now = OffsetDateTime.now();
+        
+        OffsetDateTime validFrom = earliestDelivery.plusDays(5);
+        OffsetDateTime validUntil = latestDelivery.plusDays(30);
+        
+        System.out.println("⏱️ Earliest delivery date: " + earliestDelivery);
+        System.out.println("⏱️ Latest delivery date: " + latestDelivery);
+
+
+
+        boolean isValid = now.isAfter(validFrom) && now.isBefore(validUntil);
+        System.out.println(isValid ? "✅ Within valid solicitation timeframe" : "Outside valid timeframe");
+        return isValid;
+    }
+
+    private void storeKeyIdentifiers(String amazonOrderId, String marketplaceId) {
+        System.out.println("✅ Stored identifiers - OrderId: " + amazonOrderId + ", MarketplaceId: " + marketplaceId);
+    }
+
+    private void initializeSolicitationsApi() {
+        solicitationsApi = new SolicitationsApi.Builder()
+                .lwaAuthorizationCredentials(lwaCredentials)
+                .endpoint(Constants.BACKEND_URL)
+                .disableAccessTokenCache()
+                .build();
+        System.out.println("Solicitations API client initialized");
+    }
+
+    private boolean canSolicitReview(String amazonOrderId, List<String> marketplaceIds) {
+        try {
+            GetSolicitationActionsForOrderResponse response = 
+                solicitationsApi.getSolicitationActionsForOrder(amazonOrderId, marketplaceIds);
+            for (LinkObject link : response.getLinks().getActions()) {
+                if (link.getName().contains("productReviewAndSellerFeedback")) {
+                    System.out.println("✅ Can solicit review for this order");
+                    return true;
+                }
+            }
+            return false;
+        } catch (ApiException | LWAException e) {
+            throw new RuntimeException("Failed to get solicitation actions", e);
+        }
+    }
+
+    private void solicitProductReview(String amazonOrderId, List<String> marketplaceIds) {
+        try {
+            CreateProductReviewAndSellerFeedbackSolicitationResponse response = 
+                solicitationsApi.createProductReviewAndSellerFeedbackSolicitation(amazonOrderId, marketplaceIds);
+            System.out.println("✅ Product review solicitation sent successfully");
+        } catch (ApiException | LWAException e) {
+            throw new RuntimeException("Failed to solicit product review", e);
+        }
+    }
+}

--- a/code-recipes/java/src/main/resources/shipped.json
+++ b/code-recipes/java/src/main/resources/shipped.json
@@ -1,0 +1,40 @@
+{
+  "NotificationVersion": "1.0",
+  "NotificationType": "ORDER_CHANGE",
+  "PayloadVersion": "1.0",
+  "EventTime": "2025-12-01T19:30:15.261Z",
+  "Payload": {
+    "OrderChangeNotification": {
+      "NotificationLevel": "OrderLevel",
+      "SellerId": "A2ZPJ4TLUOSWY8",
+      "AmazonOrderId": "701-1588164-9632243",
+      "OrderChangeType": "OrderStatusChange",
+      "OrderChangeTrigger": {
+        "TimeOfOrderChange": "2025-12-01T19:26:52.000Z",
+        "ChangeReason": "Order Status Change"
+      },
+      "Summary": {
+        "MarketplaceId": "A2Q3Y263D00KWC",
+        "OrderStatus": "Shipped",
+        "PurchaseDate": "2025-12-01T18:24:39.346Z",
+        "DestinationPostalCode": null,
+        "FulfillmentType": "MFN",
+        "OrderType": "StandardOrder",
+        "OrderPrograms": [],
+        "ShippingPrograms": [],
+        "OrderItems": [{
+          "OrderItemId": "148197599524161",
+          "SellerSKU": "132577",
+          "SupplySourceId": null,
+          "Quantity": 1
+        }]
+      }
+    }
+  },
+  "NotificationMetadata": {
+    "ApplicationId": "amzn1.sp.solution.cfb7a8b4-5e9e-4ed2-9a62-f3dd92d61a2f",
+    "SubscriptionId": "68730dd5-7a75-496d-bbba-b85074f246d8",
+    "PublishTime": "2025-12-01T19:30:16.976Z",
+    "NotificationId": "fb7a833f-bcb7-48b7-8f0b-10397b015af8"
+  }
+}

--- a/code-recipes/java/src/test/java/notifications/CreateDestinationRecipeTest.java
+++ b/code-recipes/java/src/test/java/notifications/CreateDestinationRecipeTest.java
@@ -1,0 +1,17 @@
+package notifications;
+
+import util.RecipeTest;
+
+import java.util.List;
+
+public class CreateDestinationRecipeTest extends RecipeTest {
+
+    protected CreateDestinationRecipeTest() {
+        super(
+                new CreateDestinationRecipe(),
+                List.of(
+                    "notifications-createDestination"
+                )
+        );
+    }
+}

--- a/code-recipes/java/src/test/java/notifications/CreateSubscriptionRecipeTest.java
+++ b/code-recipes/java/src/test/java/notifications/CreateSubscriptionRecipeTest.java
@@ -1,0 +1,17 @@
+package notifications;
+
+import util.RecipeTest;
+
+import java.util.List;
+
+public class CreateSubscriptionRecipeTest extends RecipeTest {
+
+    protected CreateSubscriptionRecipeTest() {
+        super(
+                new CreateSubscriptionRecipe(),
+                List.of(
+                    "notifications-createSubscription"
+                )
+        );
+    }
+}

--- a/code-recipes/java/src/test/java/solicitations/SolicitProductReviewRecipeTest.java
+++ b/code-recipes/java/src/test/java/solicitations/SolicitProductReviewRecipeTest.java
@@ -1,0 +1,19 @@
+package solicitations;
+
+import util.RecipeTest;
+
+import java.util.List;
+
+public class SolicitProductReviewRecipeTest extends RecipeTest {
+
+    protected SolicitProductReviewRecipeTest() {
+        super(
+                new SolicitProductReviewRecipe(),
+                List.of(
+                    "solicitations-orders-getOrder",
+                    "solicitations-getSolicitationActionsForOrder",
+                    "solicitations-createProductReviewAndSellerFeedbackSolicitation"
+                )
+        );
+    }
+}

--- a/code-recipes/test/resources/notifications/ORDER_CHANGE/shipped.json
+++ b/code-recipes/test/resources/notifications/ORDER_CHANGE/shipped.json
@@ -1,0 +1,40 @@
+{
+  "NotificationVersion": "1.0",
+  "NotificationType": "ORDER_CHANGE",
+  "PayloadVersion": "1.0",
+  "EventTime": "2025-12-01T19:30:15.261Z",
+  "Payload": {
+    "OrderChangeNotification": {
+      "NotificationLevel": "OrderLevel",
+      "SellerId": "A2ZPJ4TLUOSWY8",
+      "AmazonOrderId": "701-1588164-9632243",
+      "OrderChangeType": "OrderStatusChange",
+      "OrderChangeTrigger": {
+        "TimeOfOrderChange": "2025-12-01T19:26:52.000Z",
+        "ChangeReason": "Order Status Change"
+      },
+      "Summary": {
+        "MarketplaceId": "A2Q3Y263D00KWC",
+        "OrderStatus": "Shipped",
+        "PurchaseDate": "2025-12-01T18:24:39.346Z",
+        "DestinationPostalCode": null,
+        "FulfillmentType": "MFN",
+        "OrderType": "StandardOrder",
+        "OrderPrograms": [],
+        "ShippingPrograms": [],
+        "OrderItems": [{
+          "OrderItemId": "148197599524161",
+          "SellerSKU": "132577",
+          "SupplySourceId": null,
+          "Quantity": 1
+        }]
+      }
+    }
+  },
+  "NotificationMetadata": {
+    "ApplicationId": "amzn1.sp.solution.cfb7a8b4-5e9e-4ed2-9a62-f3dd92d61a2f",
+    "SubscriptionId": "68730dd5-7a75-496d-bbba-b85074f246d8",
+    "PublishTime": "2025-12-01T19:30:16.976Z",
+    "NotificationId": "fb7a833f-bcb7-48b7-8f0b-10397b015af8"
+  }
+}

--- a/code-recipes/test/responses/notifications-createDestination.json
+++ b/code-recipes/test/responses/notifications-createDestination.json
@@ -1,0 +1,11 @@
+{
+  "payload": {
+    "destinationId": "dest-12345-abcde-67890",
+    "name": "sp-api-destination",
+    "resource": {
+      "sqs": {
+        "arn": "arn:aws:sqs:us-east-1:123456789012:sp-api-notifications"
+      }
+    }
+  }
+}

--- a/code-recipes/test/responses/notifications-createSubscription.json
+++ b/code-recipes/test/responses/notifications-createSubscription.json
@@ -1,0 +1,7 @@
+{
+  "payload": {
+    "subscriptionId": "sub-98765-fghij-43210",
+    "payloadVersion": "1.0",
+    "destinationId": "dest-12345-abcde-67890"
+  }
+}

--- a/code-recipes/test/responses/notifications-getDestinations.json
+++ b/code-recipes/test/responses/notifications-getDestinations.json
@@ -1,0 +1,13 @@
+{
+  "payload": [
+    {
+      "destinationId": "dest-12345-abcde-67890",
+      "name": "sp-api-destination",
+      "resource": {
+        "sqs": {
+          "arn": "arn:aws:sqs:us-east-1:123456789012:sp-api-notifications"
+        }
+      }
+    }
+  ]
+}

--- a/code-recipes/test/responses/notifications-getSubscription.json
+++ b/code-recipes/test/responses/notifications-getSubscription.json
@@ -1,0 +1,7 @@
+{
+  "payload": {
+    "subscriptionId": "sub-98765-fghij-43210",
+    "payloadVersion": "1.0",
+    "destinationId": "dest-12345-abcde-67890"
+  }
+}

--- a/code-recipes/test/responses/solicitations-createProductReviewAndSellerFeedbackSolicitation.json
+++ b/code-recipes/test/responses/solicitations-createProductReviewAndSellerFeedbackSolicitation.json
@@ -1,0 +1,8 @@
+{
+  "_links": {
+    "self": {
+      "href": "/solicitations/v1/orders/123-4567890-1234567/solicitations/productReviewAndSellerFeedback",
+      "name": "productReviewAndSellerFeedback"
+    }
+  }
+}

--- a/code-recipes/test/responses/solicitations-getSolicitationActionsForOrder.json
+++ b/code-recipes/test/responses/solicitations-getSolicitationActionsForOrder.json
@@ -1,0 +1,13 @@
+{
+  "_links": {
+    "self": {
+      "href": "/solicitations/v1/orders/123-4567890-1234567"
+    },
+    "actions": [
+      {
+        "href": "/solicitations/v1/orders/123-4567890-1234567/solicitations/productReviewAndSellerFeedback?marketplaceIds=ATVPDKIKX0DER",
+        "name": "productReviewAndSellerFeedback"
+      }
+    ]
+  }
+}

--- a/code-recipes/test/responses/solicitations-orders-getOrder.json
+++ b/code-recipes/test/responses/solicitations-orders-getOrder.json
@@ -1,0 +1,71 @@
+{
+    "payload": {
+        "BuyerInfo": {
+            "BuyerEmail": "<buyer-email>",
+            "BuyerCounty": "<buyer-county>"
+        },
+        "AmazonOrderId": "701-6210829-5037842",
+        "EarliestDeliveryDate": "2025-11-21T03:00:00Z",
+        "EarliestShipDate": "2025-08-18T03:00:00Z",
+        "SalesChannel": "Amazon.com.br",
+        "AutomatedShippingSettings": {
+            "HasAutomatedShippingSettings": false
+        },
+        "OrderStatus": "Shipped",
+        "NumberOfItemsShipped": 1,
+        "OrderType": "StandardOrder",
+        "IsPremiumOrder": false,
+        "IsPrime": false,
+        "FulfillmentChannel": "MFN",
+        "NumberOfItemsUnshipped": 0,
+        "HasRegulatedItems": false,
+        "IsReplacementOrder": false,
+        "IsSoldByAB": false,
+        "LatestShipDate": "2025-08-19T02:59:59Z",
+        "PaymentExecutionDetail": [
+            {
+                "AuthorizationCode": "<authorization-code>",
+                "Payment": {
+                    "CurrencyCode": "BRL",
+                    "Amount": "1.00"
+                },
+                "PaymentMethod": "CreditCard",
+                "AcquirerId": "<acquirer-id>",
+                "CardBrand": "MasterCard"
+            }
+        ],
+        "ShipServiceLevel": "EXP DOM 6",
+        "DefaultShipFromLocationAddress": {
+            "AddressLine2": "null",
+            "StateOrRegion": "SÃO PAULO",
+            "AddressLine1": "null",
+            "PostalCode": "<postal-code>",
+            "City": "<city>",
+            "CountryCode": "BR",
+            "Name": "null"
+        },
+        "IsISPU": false,
+        "MarketplaceId": "A2Q3Y263D00KWC",
+        "LatestDeliveryDate": "2025-11-30T02:59:59Z",
+        "PurchaseDate": "2025-08-15T11:25:50Z",
+        "ShippingAddress": {
+            "StateOrRegion": "SP",
+            "PostalCode": "<postal-code>",
+            "City": "<city>",
+            "CountryCode": "BR"
+        },
+        "IsAccessPointOrder": false,
+        "PaymentMethod": "Other",
+        "IsBusinessOrder": false,
+        "OrderTotal": {
+            "CurrencyCode": "BRL",
+            "Amount": "1.00"
+        },
+        "PaymentMethodDetails": [
+            "CreditCard"
+        ],
+        "IsGlobalExpressEnabled": false,
+        "LastUpdateDate": "2025-09-19T03:36:58Z",
+        "ShipmentServiceLevelCategory": "Expedited"
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The goal of this PR is to migrate the solicitations sample solution to code-recipes. The Sample Solution encompassed both notifications and solicitations API, leading to the creation of 3 code recipes:
1. Notifications Create Destination
2. Notifications Create Subscription
3. Solicitations Solicit Product Review

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
