### PR TITLE
feat(sp-api-dev-mcp): Add Fulfillment Outbound API migration support

### DIFF
--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/index.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/index.ts
@@ -52,7 +52,7 @@ class SPAPIDevMCPServer {
     this.catalogLoader = new CatalogLoader();
 
     this.migrationAssistantTool = new SPAPIMigrationAssistantTool(
-      join(dataRoot, "resources", "orders-api-migration-data.json"),
+      join(dataRoot, "resources"),
     );
     this.CodeGenerationTool = new CodeGenerationTool();
     this.optimizationTool = new OptimizationTool();
@@ -119,6 +119,64 @@ class SPAPIDevMCPServer {
         };
       },
     );
+
+    // Register Outbound Fulfillment Migration Data Resource
+    this.server.registerResource(
+      "outbound-fulfillment-migration-data",
+      "sp-api://migration/outbound-fulfillment",
+      {
+        description:
+          "Migration mapping data for Fulfillment Outbound API v2020-07-01 to v2025-09-24. Contains deprecated attributes, unsupported fields, attribute mappings, new features, and API method mappings.",
+        mimeType: "application/json",
+      },
+      async () => {
+        const resourcePath = join(
+          dataRoot,
+          "resources",
+          "outbound-fulfillment-migration-data.json",
+        );
+        const content = readFileSync(resourcePath, "utf-8");
+        return {
+          contents: [
+            {
+              uri: "sp-api://migration/outbound-fulfillment",
+              mimeType: "application/json",
+              text: content,
+            },
+          ],
+        };
+      },
+    );
+
+    // Register Fulfillment Outbound v2025-09-24 Swagger/OpenAPI Spec
+    this.server.registerResource(
+      "fulfillment-outbound-v2025-09-24-api-model",
+      "sp-api://models/fulfillment-outbound-2025-09-24",
+      {
+        description:
+          "Swagger/OpenAPI 2.0 specification for the Selling Partner API Fulfillment Outbound v2025-09-24. " +
+          "Contains all endpoints, request/response schemas, and data model definitions for Multi-Channel Fulfillment operations including " +
+          "order creation, previews, delivery offers, tracking, and fulfillment service tenancy management.",
+        mimeType: "application/json",
+      },
+      async () => {
+        const resourcePath = join(
+          dataRoot,
+          "resources",
+          "fulfillmentOutbound_2025-09-24.json",
+        );
+        const content = readFileSync(resourcePath, "utf-8");
+        return {
+          contents: [
+            {
+              uri: "sp-api://models/fulfillment-outbound-2025-09-24",
+              mimeType: "application/json",
+              text: content,
+            },
+          ],
+        };
+      },
+    );
   }
 
   private setupTools(): void {
@@ -135,7 +193,7 @@ class SPAPIDevMCPServer {
           "instead of source_code to get accurate per-file line numbers. " +
           "Only use source_code when the user pastes a code snippet directly. " +
           "Do NOT strip comments, blank lines, or reformat the code — preserve it exactly as-is. " +
-          "Supported Migrations: Orders API v0 → v2026-01-01",
+          "Supported Migrations: Orders API v0 → v2026-01-01, Fulfillment Outbound API v2020-07-01 → v2025-09-24",
         inputSchema: migrationAssistantSchema,
       },
       async (args: any) => {

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/resources/fulfillmentOutbound_2025-09-24.json
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/resources/fulfillmentOutbound_2025-09-24.json
@@ -1,0 +1,5784 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "The Selling Partner API for Fulfillment Outbound lets you create applications that help a merchant fulfill Multi-Channel Fulfillment orders using their inventory in Amazon's fulfillment network. You can get information on both potential and existing fulfillment orders.",
+    "version": "2025-09-24",
+    "title": "The Selling Partner API for Fulfillment Outbound",
+    "contact": {
+      "name": "Selling Partner API Developer Support",
+      "url": "https://sellercentral.amazon.com/gp/mws/contactus.html"
+    },
+    "license": {
+      "name": "Apache License 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "host": "sellingpartnerapi-na.amazon.com",
+  "schemes": ["https"],
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
+  "paths": {
+    "/fulfillment/outbound/2025-09-24/previews": {
+      "x-amzn-api-sandbox": {
+        "dynamic": {}
+      },
+      "post": {
+        "tags": ["fulfillmentOutbound", "fulfillmentPreviews"],
+        "description": "Returns a list of fulfillment order previews based on shipping criteria that you specify.\n\n**Usage Plan:**\n\n| Rate (requests per second) | Burst |\n| ---- | ---- |\n| 2 | 30 |\n\nThe `x-amzn-RateLimit-Limit` response header returns the usage plan rate limits that were applied to the requested operation, when available. The preceding table indicates the default rate and burst values for this operation. Selling partners whose business demands require higher throughput may see higher rate and burst values than those shown here. For more information, see [Usage Plans and Rate Limits in the Selling Partner API](https://developer-docs.amazon.com/sp-api/docs/usage-plans-and-rate-limits-in-the-sp-api).",
+        "operationId": "getOrderPreview",
+        "parameters": [
+          {
+            "name": "x-amzn-fulfillment-service-id",
+            "in": "header",
+            "description": "The identifier of the fulfillment service used for this operation.",
+            "required": false,
+            "type": "string",
+            "maxLength": 40,
+            "x-example": "FS01-o8vlfw8b1tiu1"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GetOrderPreviewRequest"
+            },
+            "description": "GetOrderPreviewRequest parameter",
+            "x-examples": {
+              "application/json": {
+                "deliveryServiceLevels": ["STANDARD"],
+                "origin": {
+                  "countryCode": "US"
+                },
+                "destination": {
+                  "deliveryAddress": {
+                    "name": "Shopper Name",
+                    "addressLine1": "1000 Winthrop Ave N",
+                    "addressLine2": "Floor 19",
+                    "addressLine3": "ATTN: Shopper",
+                    "city": "Seattle",
+                    "districtOrCounty": "None",
+                    "countryCode": "US",
+                    "phone": "123-456-7890",
+                    "postalCode": "98103",
+                    "stateOrRegion": "WA",
+                    "email": "shopper@email.com"
+                  }
+                },
+                "services": {
+                  "packaging": {
+                    "blankBox": "REQUIRED"
+                  },
+                  "delivery": {
+                    "signatureOnDelivery": "ADULT_REQUIRED"
+                  },
+                  "additionalServices": {
+                    "serviceName": "REQUIRED"
+                  }
+                },
+                "lineItems": [
+                  {
+                    "product": {
+                      "productIdentifier": {
+                        "amazonSku": "BOOK-123-HC"
+                      },
+                      "perUnitDeclaredValue": {
+                        "currencyCode": "USD",
+                        "amount": "14.99"
+                      }
+                    },
+                    "amount": {
+                      "unit": "EACHES",
+                      "value": "2"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/GetOrderPreviewResponse"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            },
+            "examples": {
+              "application/json": {
+                "plannedShipments": [
+                  {
+                    "estimatedShippingWeight": {
+                      "unit": "KG",
+                      "value": "2"
+                    },
+                    "items": [
+                      {
+                        "productIdentifier": {
+                          "amazonSku": "someSku"
+                        },
+                        "amount": {
+                          "unit": "EACHES",
+                          "value": "1.0"
+                        }
+                      }
+                    ],
+                    "services": {
+                      "packaging": {
+                        "blankBox": "REQUIRED"
+                      },
+                      "delivery": {
+                        "signatureOnDelivery": "ADULT_REQUIRED"
+                      },
+                      "additionalServices": {
+                        "serviceName": "REQUIRED"
+                      }
+                    },
+                    "offers": [
+                      {
+                        "deliveryServiceLevel": "STANDARD",
+                        "deliveryInterval": {
+                          "startTime": "2025-04-21T12:34:56Z",
+                          "endTime": "2025-04-22T12:34:56Z"
+                        },
+                        "estimatedPrice": {
+                          "rollupPrices": [
+                            {
+                              "type": "MCFTransportationFee",
+                              "value": {
+                                "currencyCode": "USD",
+                                "amount": "4.25"
+                              }
+                            }
+                          ],
+                          "totalPrice": {
+                            "currencyCode": "USD",
+                            "amount": "4.25"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "constraints": [
+                  {
+                    "message": "There is not enough quantity of item xyz.",
+                    "type": "ValidationError",
+                    "code": "ItemQuantityNotAvailable",
+                    "details": [
+                      {
+                        "type": "someType",
+                        "value": "someValue"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "400": {
+            "description": "Request has missing or invalid parameters and cannot be parsed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "401": {
+            "description": "The request's Authorization header is not formatted correctly or does not contain a valid token.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "403": {
+            "description": "Indicates that access to the resource is forbidden. Possible reasons include Access Denied, Unauthorized, Expired Token, or Invalid Signature.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "404": {
+            "description": "The resource specified does not exist.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "413": {
+            "description": "The request size exceeded the maximum accepted size.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "415": {
+            "description": "The request payload is in an unsupported format.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "429": {
+            "description": "The frequency of requests was greater than allowed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected condition occurred that prevented the server from fulfilling the request.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "503": {
+            "description": "Temporary overloading or maintenance of the server.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fulfillment/outbound/2025-09-24/offers": {
+      "x-amzn-api-sandbox": {
+        "dynamic": {}
+      },
+      "post": {
+        "tags": ["fulfillmentOutbound", "offers"],
+        "description": "Returns delivery options that include an estimated delivery date and offer expiration, based on criteria that you specify.\n\n**Usage Plan:**\n\n| Rate (requests per second) | Burst |\n| ---- | ---- |\n| 5 | 30 |\n\nThe `x-amzn-RateLimit-Limit` response header returns the usage plan rate limits that were applied to the requested operation, when available. The preceding table indicates the default rate and burst values for this operation. Selling partners whose business demands require higher throughput may see higher rate and burst values than those shown here. For more information, see [Usage Plans and Rate Limits in the Selling Partner API](https://developer-docs.amazon.com/sp-api/docs/usage-plans-and-rate-limits-in-the-sp-api).",
+        "operationId": "getOffers",
+        "parameters": [
+          {
+            "name": "x-amzn-fulfillment-service-id",
+            "in": "header",
+            "description": "The identifier of the fulfillment service used for this operation.",
+            "required": false,
+            "type": "string",
+            "maxLength": 40,
+            "x-example": "FS01-o8vlfw8b1tiu1"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GetOffersRequest"
+            },
+            "description": "GetOffersRequest parameter",
+            "x-examples": {
+              "application/json": {
+                "product": {
+                  "productIdentifier": {
+                    "amazonSku": "someSku"
+                  }
+                },
+                "amount": {
+                  "unit": "EACHES",
+                  "value": "1.0"
+                },
+                "origin": {
+                  "countryCode": "US"
+                },
+                "destination": {
+                  "ipAddress": "192.168.0.1",
+                  "deliveryAddress": {
+                    "addressLine1": "1000 Winthrop Ave N",
+                    "addressLine2": "Floor 19",
+                    "addressLine3": "ATTN: Shopper",
+                    "city": "Seattle",
+                    "districtOrCounty": "None",
+                    "countryCode": "US",
+                    "postalCode": "98103",
+                    "stateOrRegion": "WA"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/GetOffersResponse"
+            },
+            "examples": {
+              "application/json": {
+                "offers": [
+                  {
+                    "expiryTime": "2023-10-11T18:00:00Z",
+                    "deliveryInterval": {
+                      "startTime": "2023-10-13T10:00:00Z",
+                      "endTime": "2023-10-14T16:00:00Z"
+                    },
+                    "policy": {
+                      "messaging": {
+                        "text": "Get it as soon as Wed, Aug 23",
+                        "locale": "en-US"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "400": {
+            "description": "Request has missing or invalid parameters and cannot be parsed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "401": {
+            "description": "The request's Authorization header is not formatted correctly or does not contain a valid token.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "403": {
+            "description": "Indicates that access to the resource is forbidden. Possible reasons include Access Denied, Unauthorized, Expired Token, or Invalid Signature.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "404": {
+            "description": "The resource specified does not exist.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "413": {
+            "description": "The request size exceeded the maximum accepted size.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "415": {
+            "description": "The request payload is in an unsupported format.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "429": {
+            "description": "The frequency of requests was greater than allowed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected condition occurred that prevented the server from fulfilling the request.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "503": {
+            "description": "Temporary overloading or maintenance of the server.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fulfillment/outbound/2025-09-24/orders/{orderId}/cancel": {
+      "x-amzn-api-sandbox": {
+        "dynamic": {}
+      },
+      "put": {
+        "tags": ["fulfillmentOutbound", "fulfillmentOrders"],
+        "description": "Requests that Amazon stop attempting to fulfill the fulfillment order indicated by the specified order identifier.\n\n**Usage Plan:**\n\n| Rate (requests per second) | Burst |\n| ---- | ---- |\n| 2 | 30 |\n\nThe `x-amzn-RateLimit-Limit` response header returns the usage plan rate limits that were applied to the requested operation, when available. The preceding table indicates the default rate and burst values for this operation. Selling partners whose business demands require higher throughput may see higher rate and burst values than those shown here. For more information, see [Usage Plans and Rate Limits in the Selling Partner API](https://developer-docs.amazon.com/sp-api/docs/usage-plans-and-rate-limits-in-the-sp-api).",
+        "operationId": "cancelOrder",
+        "parameters": [
+          {
+            "name": "x-amzn-fulfillment-service-id",
+            "in": "header",
+            "description": "The identifier of the fulfillment service used for this operation.",
+            "required": false,
+            "type": "string",
+            "maxLength": 40,
+            "x-example": "FS01-o8vlfw8b1tiu1"
+          },
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "The identifier assigned to the item by the merchant when the fulfillment order was created.",
+            "required": true,
+            "type": "string",
+            "maxLength": 40,
+            "x-example": "order-123"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success.",
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "400": {
+            "description": "Request has missing or invalid parameters and cannot be parsed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "401": {
+            "description": "The request's Authorization header is not formatted correctly or does not contain a valid token.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "403": {
+            "description": "Indicates that access to the resource is forbidden. Possible reasons include Access Denied, Unauthorized, Expired Token, or Invalid Signature.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "404": {
+            "description": "The resource specified does not exist.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "413": {
+            "description": "The request size exceeded the maximum accepted size.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "415": {
+            "description": "The request payload is in an unsupported format.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "429": {
+            "description": "The frequency of requests was greater than allowed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected condition occurred that prevented the server from fulfilling the request.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "503": {
+            "description": "Temporary overloading or maintenance of the server.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fulfillment/outbound/2025-09-24/orders/{orderId}/status": {
+      "x-amzn-api-sandbox-only": true,
+      "x-amzn-api-sandbox": {
+        "dynamic": {}
+      },
+      "put": {
+        "tags": ["fulfillmentOutbound", "fulfillmentOrders"],
+        "description": "Requests that Amazon update the status of an order in the sandbox testing environment. This is a sandbox-only operation and must be directed to a sandbox endpoint. Refer to [Fulfillment Outbound Dynamic Sandbox Guide](https://developer-docs.amazon.com/sp-api/docs/fulfillment-outbound-dynamic-sandbox-guide) and [Selling Partner API sandbox](https://developer-docs.amazon.com/sp-api/docs/the-selling-partner-api-sandbox) for more information.",
+        "operationId": "updateOrderStatus",
+        "parameters": [
+          {
+            "name": "x-amzn-fulfillment-service-id",
+            "in": "header",
+            "description": "The identifier of the fulfillment service used for this operation.",
+            "required": false,
+            "type": "string",
+            "maxLength": 40,
+            "x-example": "FS01-o8vlfw8b1tiu1"
+          },
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "The identifier assigned to the order by the merchant when the fulfillment order was created.",
+            "required": true,
+            "type": "string",
+            "maxLength": 40,
+            "x-example": "order-123"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateOrderStatusRequest"
+            },
+            "description": "The new status of the fulfillment order to update.",
+            "x-examples": {
+              "application/json": {
+                "status": "PROCESSING"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success.",
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "400": {
+            "description": "Request has missing or invalid parameters and cannot be parsed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "401": {
+            "description": "The request's Authorization header is not formatted correctly or does not contain a valid token.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "403": {
+            "description": "Indicates that access to the resource is forbidden. Possible reasons include Access Denied, Unauthorized, Expired Token, or Invalid Signature.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "404": {
+            "description": "The resource specified does not exist.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "413": {
+            "description": "The request size exceeded the maximum accepted size.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "415": {
+            "description": "The request payload is in an unsupported format.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "429": {
+            "description": "The frequency of requests was greater than allowed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected condition occurred that prevented the server from fulfilling the request.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "503": {
+            "description": "Temporary overloading or maintenance of the server.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fulfillment/outbound/2025-09-24/orders/{orderId}/packages/{packageNumber}": {
+      "x-amzn-api-sandbox-only": true,
+      "x-amzn-api-sandbox": {
+        "dynamic": {}
+      },
+      "put": {
+        "tags": ["fulfillmentOutbound", "fulfillmentOrders"],
+        "description": "Updates package information for a specific package in a fulfillment order. This is a sandbox-only operation and must be directed to a sandbox endpoint.",
+        "operationId": "updatePackage",
+        "parameters": [
+          {
+            "name": "x-amzn-fulfillment-service-id",
+            "in": "header",
+            "description": "The identifier of the fulfillment service used for this operation.",
+            "required": false,
+            "type": "string",
+            "maxLength": 40,
+            "x-example": "FS01-o8vlfw8b1tiu1"
+          },
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "The identifier assigned to the order by the merchant when the fulfillment order was created.",
+            "required": true,
+            "type": "string",
+            "maxLength": 40,
+            "x-example": "order-123"
+          },
+          {
+            "name": "packageNumber",
+            "in": "path",
+            "description": "The package number to update.",
+            "required": true,
+            "type": "string",
+            "x-example": "1"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdatePackageRequest"
+            },
+            "description": "The package information to update.",
+            "x-examples": {
+              "application/json": {
+                "status": "DELIVERED"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success.",
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "400": {
+            "description": "Request has missing or invalid parameters and cannot be parsed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "401": {
+            "description": "The request's Authorization header is not formatted correctly or does not contain a valid token.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "403": {
+            "description": "Indicates that access to the resource is forbidden. Possible reasons include Access Denied, Unauthorized, Expired Token, or Invalid Signature.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "404": {
+            "description": "The resource specified does not exist.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "413": {
+            "description": "The request size exceeded the maximum accepted size.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "415": {
+            "description": "The request payload is in an unsupported format.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "429": {
+            "description": "The frequency of requests was greater than allowed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected condition occurred that prevented the server from fulfilling the request.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "503": {
+            "description": "Temporary overloading or maintenance of the server.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fulfillment/outbound/2025-09-24/orders/{orderId}": {
+      "x-amzn-api-sandbox": {
+        "dynamic": {}
+      },
+      "put": {
+        "tags": ["fulfillmentOutbound", "fulfillmentOrders"],
+        "description": "Updates and/or requests shipment for a fulfillment order with an order hold on it.\n\n**Usage Plan:**\n\n| Rate (requests per second) | Burst |\n| ---- | ---- |\n| 2 | 30 |\n\nThe `x-amzn-RateLimit-Limit` response header returns the usage plan rate limits that were applied to the requested operation, when available. The preceding table indicates the default rate and burst values for this operation. Selling partners whose business demands require higher throughput may see higher rate and burst values than those shown here. For more information, see [Usage Plans and Rate Limits in the Selling Partner API](https://developer-docs.amazon.com/sp-api/docs/usage-plans-and-rate-limits-in-the-sp-api).",
+        "operationId": "updateOrder",
+        "parameters": [
+          {
+            "name": "x-amzn-fulfillment-service-id",
+            "in": "header",
+            "description": "The identifier of the fulfillment service used for this operation.",
+            "required": false,
+            "type": "string",
+            "maxLength": 40,
+            "x-example": "FS01-o8vlfw8b1tiu1"
+          },
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "The fulfillment order identifier identifying the order that the merchant wants to update.",
+            "required": true,
+            "type": "string",
+            "maxLength": 40,
+            "x-example": "orderNumberThree"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateOrderRequest"
+            },
+            "description": "UpdateOrderRequest parameter",
+            "x-examples": {
+              "application/json": {
+                "fulfillmentAction": "HOLD"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success.",
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "400": {
+            "description": "Request has missing or invalid parameters and cannot be parsed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "401": {
+            "description": "The request's Authorization header is not formatted correctly or does not contain a valid token.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "403": {
+            "description": "Indicates that access to the resource is forbidden. Possible reasons include Access Denied, Unauthorized, Expired Token, or Invalid Signature.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "404": {
+            "description": "The resource specified does not exist.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "413": {
+            "description": "The request size exceeded the maximum accepted size.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "415": {
+            "description": "The request payload is in an unsupported format.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "429": {
+            "description": "The frequency of requests was greater than allowed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected condition occurred that prevented the server from fulfilling the request.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "503": {
+            "description": "Temporary overloading or maintenance of the server.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["fulfillmentOutbound", "fulfillmentOrders"],
+        "description": "Returns the fulfillment order indicated by the specified order identifier.\n\n**Usage Plan:**\n\n| Rate (requests per second) | Burst |\n| ---- | ---- |\n| 2 | 30 |\n\nThe `x-amzn-RateLimit-Limit` response header returns the usage plan rate limits that were applied to the requested operation, when available. The preceding table indicates the default rate and burst values for this operation. Selling partners whose business demands require higher throughput may see higher rate and burst values than those shown here. For more information, see [Usage Plans and Rate Limits in the Selling Partner API](https://developer-docs.amazon.com/sp-api/docs/usage-plans-and-rate-limits-in-the-sp-api).",
+        "operationId": "getOrder",
+        "parameters": [
+          {
+            "name": "x-amzn-fulfillment-service-id",
+            "in": "header",
+            "description": "The identifier of the fulfillment service used for this operation.",
+            "required": false,
+            "type": "string",
+            "maxLength": 40,
+            "x-example": "FS01-o8vlfw8b1tiu1"
+          },
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "The fulfillment order identifier identifying the order that the merchant wants to update.",
+            "required": true,
+            "type": "string",
+            "maxLength": 40,
+            "x-example": "orderNumberThree"
+          },
+          {
+            "name": "shipments",
+            "in": "query",
+            "description": "Whether to include shipment data in the response. Included by default.",
+            "type": "string",
+            "enum": ["INCLUDE", "EXCLUDE"],
+            "x-docgen-enum-table-extension": [
+              {
+                "value": "INCLUDE",
+                "description": "Response schema will include shipments data. This is the default behavior."
+              },
+              {
+                "value": "EXCLUDE",
+                "description": "Response schema will not include shipments data."
+              }
+            ],
+            "x-example": "EXCLUDE"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/GetOrderResponse"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            },
+            "examples": {
+              "application/json": {
+                "fulfillmentOrder": {
+                  "deliveryServiceLevel": "STANDARD",
+                  "orderId": "ABC123XYZ",
+                  "receiveTime": "2025-04-21T10:30:00Z",
+                  "status": "PROCESSING",
+                  "fulfillmentAction": "HOLD",
+                  "fulfillmentPolicy": "FILL_ALL_AVAILABLE",
+                  "statusUpdateTime": "2025-04-21T11:45:00Z",
+                  "origin": {
+                    "countryCode": "US"
+                  },
+                  "destination": {
+                    "deliveryAddress": {
+                      "name": "Shopper Name",
+                      "addressLine1": "1000 Winthrop Ave N",
+                      "addressLine2": "Floor 19",
+                      "addressLine3": "ATTN: Shopper",
+                      "city": "Seattle",
+                      "districtOrCounty": "None",
+                      "countryCode": "US",
+                      "phone": "123-456-7890",
+                      "postalCode": "98103",
+                      "stateOrRegion": "WA",
+                      "email": "shopper@email.com"
+                    },
+                    "deliveryNotes": "Please beware of dogs.",
+                    "dropOffLocation": {
+                      "type": "FALLBACK_NEIGHBOR_DELIVERY",
+                      "attributes": {
+                        "neighborName": "neighborName",
+                        "houseNumber": "houseNumber"
+                      }
+                    }
+                  },
+                  "services": {
+                    "packaging": {
+                      "blankBox": "REQUIRED",
+                      "packingSlip": {
+                        "templateName": "templateName",
+                        "templateAttributes": {
+                          "attributeName1": "attributeValue1",
+                          "attributeName2": "attributeValue2"
+                        }
+                      }
+                    },
+                    "delivery": {
+                      "signatureOnDelivery": "REQUIRED",
+                      "deliverTogether": "REQUIRED"
+                    },
+                    "additionalServices": {
+                      "serviceName": "REQUIRED"
+                    }
+                  },
+                  "lineItems": [
+                    {
+                      "lineItemId": "someLineItemId",
+                      "product": {
+                        "productIdentifier": {
+                          "amazonSku": "BOOK-123-HC"
+                        },
+                        "perUnitDeclaredValue": {
+                          "currencyCode": "USD",
+                          "amount": "14.99"
+                        }
+                      },
+                      "amount": {
+                        "unit": "EACHES",
+                        "value": "1.0"
+                      },
+                      "services": {
+                        "packaging": {
+                          "packingSlip": {
+                            "templateName": "templateName",
+                            "templateAttributes": {
+                              "attributeName1": "attributeValue1",
+                              "attributeName2": "attributeValue2"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "shipments": [
+                    {
+                      "amazonShipmentId": "SHIP901234",
+                      "fulfillmentCenter": {
+                        "id": "FC456"
+                      },
+                      "status": "SHIPPED",
+                      "shipTime": "2025-04-21T15:00:00Z",
+                      "deliveryTime": "2025-04-23T12:00:00Z",
+                      "items": [
+                        {
+                          "productIdentifier": {
+                            "amazonSku": "SKU123"
+                          },
+                          "lineItemId": "LI789012",
+                          "amount": {
+                            "value": "1.0",
+                            "unit": "EACHES"
+                          },
+                          "unitIdentifiers": {
+                            "SKU": ["ABC123", "XYZ789"],
+                            "ASIN": ["B01234567", "B07654321"],
+                            "UPC": ["012345678901", "987654321098"]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Request has missing or invalid parameters and cannot be parsed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "401": {
+            "description": "The request's Authorization header is not formatted correctly or does not contain a valid token.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "403": {
+            "description": "Indicates that access to the resource is forbidden. Possible reasons include Access Denied, Unauthorized, Expired Token, or Invalid Signature.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "404": {
+            "description": "The resource specified does not exist.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "413": {
+            "description": "The request size exceeded the maximum accepted size.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "415": {
+            "description": "The request payload is in an unsupported format.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "429": {
+            "description": "The frequency of requests was greater than allowed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected condition occurred that prevented the server from fulfilling the request.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "503": {
+            "description": "Temporary overloading or maintenance of the server.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fulfillment/outbound/2025-09-24/orders": {
+      "x-amzn-api-sandbox": {
+        "dynamic": {}
+      },
+      "get": {
+        "tags": ["fulfillmentOutbound", "fulfillmentOrders"],
+        "description": "Returns a list of fulfillment orders fulfilled after (or at) a specified date-time, or indicated by the next token parameter.\n\n**Usage Plan:**\n\n| Rate (requests per second) | Burst |\n| ---- | ---- |\n| 2 | 30 |\n\nThe `x-amzn-RateLimit-Limit` response header returns the usage plan rate limits that were applied to the requested operation, when available. The preceding table indicates the default rate and burst values for this operation. Selling partners whose business demands require higher throughput may see higher rate and burst values than those shown here. For more information, see [Usage Plans and Rate Limits in the Selling Partner API](https://developer-docs.amazon.com/sp-api/docs/usage-plans-and-rate-limits-in-the-sp-api).",
+        "operationId": "listOrders",
+        "parameters": [
+          {
+            "name": "x-amzn-fulfillment-service-id",
+            "in": "header",
+            "description": "The identifier of the fulfillment service used for this operation.",
+            "required": false,
+            "type": "string",
+            "maxLength": 40,
+            "x-example": "FS01-o8vlfw8b1tiu1"
+          },
+          {
+            "name": "updatedAfter",
+            "in": "query",
+            "description": "A date used for selecting fulfillment orders updated after a specified time. Must be in ISO 8601 format.",
+            "type": "string",
+            "format": "date-time",
+            "x-example": "2025-04-01T12:00:00Z"
+          },
+          {
+            "in": "query",
+            "name": "pageToken",
+            "required": false,
+            "description": "A token to fetch a certain page when there are multiple pages worth of results.",
+            "type": "string",
+            "x-example": "someToken"
+          },
+          {
+            "name": "shipments",
+            "in": "query",
+            "description": "Whether to include shipment data in the response. Included by default.",
+            "type": "string",
+            "enum": ["INCLUDE", "EXCLUDE"],
+            "x-docgen-enum-table-extension": [
+              {
+                "value": "INCLUDE",
+                "description": "Response schema will include shipments data. This is the default behavior."
+              },
+              {
+                "value": "EXCLUDE",
+                "description": "Response schema will not include shipments data."
+              }
+            ],
+            "x-example": "EXCLUDE"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/ListOrdersResponse"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            },
+            "examples": {
+              "application/json": {
+                "fulfillmentOrders": [
+                  {
+                    "deliveryServiceLevel": "STANDARD",
+                    "orderId": "ABC123XYZ",
+                    "receiveTime": "2025-04-21T10:30:00Z",
+                    "status": "PROCESSING",
+                    "fulfillmentAction": "HOLD",
+                    "statusUpdateTime": "2025-04-21T11:45:00Z",
+                    "origin": {
+                      "countryCode": "US"
+                    },
+                    "destination": {
+                      "deliveryAddress": {
+                        "name": "Shopper Name",
+                        "addressLine1": "1000 Winthrop Ave N",
+                        "addressLine2": "Floor 19",
+                        "addressLine3": "ATTN: Shopper",
+                        "city": "Seattle",
+                        "districtOrCounty": "None",
+                        "countryCode": "US",
+                        "phone": "123-456-7890",
+                        "postalCode": "98103",
+                        "stateOrRegion": "WA",
+                        "email": "shopper@email.com"
+                      }
+                    },
+                    "lineItems": [
+                      {
+                        "lineItemId": "someLineItemId",
+                        "product": {
+                          "productIdentifier": {
+                            "amazonSku": "BOOK-123-HC"
+                          },
+                          "perUnitDeclaredValue": {
+                            "currencyCode": "USD",
+                            "amount": "14.99"
+                          }
+                        },
+                        "amount": {
+                          "unit": "EACHES",
+                          "value": "1.0"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "deliveryServiceLevel": "EXPEDITED",
+                    "orderId": "DEF456UVW",
+                    "receiveTime": "2025-04-20T15:30:00Z",
+                    "status": "COMPLETE",
+                    "fulfillmentAction": "SHIP",
+                    "statusUpdateTime": "2025-04-20T18:45:00Z",
+                    "origin": {
+                      "countryCode": "US"
+                    },
+                    "destination": {
+                      "deliveryAddress": {
+                        "name": "Another Shopper",
+                        "addressLine1": "500 Pine Street",
+                        "city": "San Francisco",
+                        "countryCode": "US",
+                        "phone": "987-654-3210",
+                        "postalCode": "94103",
+                        "stateOrRegion": "CA"
+                      }
+                    },
+                    "lineItems": [
+                      {
+                        "lineItemId": "anotherLineItemId",
+                        "product": {
+                          "productIdentifier": {
+                            "amazonSku": "BOOK-123-HC"
+                          },
+                          "perUnitDeclaredValue": {
+                            "currencyCode": "USD",
+                            "amount": "14.99"
+                          }
+                        },
+                        "amount": {
+                          "unit": "EACHES",
+                          "value": "2.0"
+                        },
+                        "cancelledAmount": {
+                          "unit": "EACHES",
+                          "value": "0"
+                        },
+                        "unfulfillableAmount": {
+                          "unit": "EACHES",
+                          "value": "0"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "pagination": {
+                  "nextToken": "token123"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Request has missing or invalid parameters and cannot be parsed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "401": {
+            "description": "The request's Authorization header is not formatted correctly or does not contain a valid token.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "403": {
+            "description": "Indicates that access to the resource is forbidden. Possible reasons include Access Denied, Unauthorized, Expired Token, or Invalid Signature.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "404": {
+            "description": "The resource specified does not exist.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "413": {
+            "description": "The request size exceeded the maximum accepted size.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "415": {
+            "description": "The request payload is in an unsupported format.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "429": {
+            "description": "The frequency of requests was greater than allowed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected condition occurred that prevented the server from fulfilling the request.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "503": {
+            "description": "Temporary overloading or maintenance of the server.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["fulfillmentOutbound", "fulfillmentOrders"],
+        "description": "Requests that Amazon ship items from the merchant's inventory in Amazon's fulfillment network to a destination address.\n\n**Usage Plan:**\n\n| Rate (requests per second) | Burst |\n| ---- | ---- |\n| 2 | 30 |\n\nThe `x-amzn-RateLimit-Limit` response header returns the usage plan rate limits that were applied to the requested operation, when available. The preceding table indicates the default rate and burst values for this operation. Selling partners whose business demands require higher throughput may see higher rate and burst values than those shown here. For more information, see [Usage Plans and Rate Limits in the Selling Partner API](https://developer-docs.amazon.com/sp-api/docs/usage-plans-and-rate-limits-in-the-sp-api).",
+        "operationId": "createOrder",
+        "parameters": [
+          {
+            "name": "x-amzn-fulfillment-service-id",
+            "in": "header",
+            "description": "The identifier of the fulfillment service used for this operation.",
+            "required": false,
+            "type": "string",
+            "maxLength": 40,
+            "x-example": "FS01-o8vlfw8b1tiu1"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateOrderRequest"
+            },
+            "description": "CreateOrderRequest parameter",
+            "x-examples": {
+              "application/json": {
+                "orderId": "orderId",
+                "deliveryServiceLevel": "STANDARD",
+                "fulfillmentAction": "HOLD",
+                "fulfillmentPolicy": "FILL_ALL_AVAILABLE",
+                "origin": {
+                  "countryCode": "US"
+                },
+                "destination": {
+                  "deliveryAddress": {
+                    "name": "Shopper Name",
+                    "addressLine1": "1000 Winthrop Ave N",
+                    "addressLine2": "Floor 19",
+                    "addressLine3": "ATTN: Shopper",
+                    "city": "Seattle",
+                    "districtOrCounty": "None",
+                    "countryCode": "US",
+                    "phone": "123-456-7890",
+                    "postalCode": "98103",
+                    "stateOrRegion": "WA",
+                    "email": "shopper@email.com"
+                  }
+                },
+                "services": {
+                  "packaging": {
+                    "blankBox": "REQUIRED"
+                  },
+                  "additionalServices": {
+                    "serviceName": "REQUIRED"
+                  }
+                },
+                "lineItems": [
+                  {
+                    "lineItemId": "someLineItemId",
+                    "product": {
+                      "productIdentifier": {
+                        "amazonSku": "BOOK-123-HC"
+                      },
+                      "perUnitDeclaredValue": {
+                        "currencyCode": "USD",
+                        "amount": "14.99"
+                      }
+                    },
+                    "amount": {
+                      "unit": "EACHES",
+                      "value": "1.0"
+                    },
+                    "services": {
+                      "packaging": {
+                        "packingSlip": {
+                          "templateName": "templateName",
+                          "templateAttributes": {
+                            "attributeName1": "attributeValue1",
+                            "attributeName2": "attributeValue2"
+                          }
+                        }
+                      },
+                      "delivery": {
+                        "paymentOnDelivery": {
+                          "perUnitServicePrice": {
+                            "currencyCode": "USD",
+                            "amount": "14.99"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/CreateOrderResponse"
+            },
+            "examples": {
+              "application/json": {
+                "fulfillmentOrder": {
+                  "orderId": "ABC123XYZ",
+                  "deliveryServiceLevel": "STANDARD",
+                  "receiveTime": "2025-04-21T10:30:00Z",
+                  "status": "PROCESSING",
+                  "fulfillmentAction": "HOLD",
+                  "fulfillmentPolicy": "FILL_ALL_AVAILABLE",
+                  "statusUpdateTime": "2025-04-21T11:45:00Z",
+                  "origin": {
+                    "countryCode": "US"
+                  },
+                  "destination": {
+                    "deliveryAddress": {
+                      "name": "Shopper Name",
+                      "addressLine1": "1000 Winthrop Ave N",
+                      "addressLine2": "Floor 19",
+                      "addressLine3": "ATTN: Shopper",
+                      "city": "Seattle",
+                      "districtOrCounty": "None",
+                      "countryCode": "US",
+                      "phone": "123-456-7890",
+                      "postalCode": "98103",
+                      "stateOrRegion": "WA",
+                      "email": "shopper@email.com"
+                    },
+                    "deliveryNotes": "Please beware of dogs.",
+                    "dropOffLocation": {
+                      "type": "FALLBACK_NEIGHBOR_DELIVERY",
+                      "attributes": {
+                        "neighborName": "neighborName",
+                        "houseNumber": "houseNumber"
+                      }
+                    }
+                  },
+                  "services": {
+                    "packaging": {
+                      "blankBox": "REQUIRED",
+                      "packingSlip": {
+                        "templateName": "templateName",
+                        "templateAttributes": {
+                          "attributeName1": "attributeValue1",
+                          "attributeName2": "attributeValue2"
+                        }
+                      }
+                    },
+                    "delivery": {
+                      "signatureOnDelivery": "REQUIRED",
+                      "deliverTogether": "REQUIRED"
+                    },
+                    "additionalServices": {
+                      "serviceName": "REQUIRED"
+                    }
+                  },
+                  "lineItems": [
+                    {
+                      "lineItemId": "someLineItemId",
+                      "product": {
+                        "productIdentifier": {
+                          "amazonSku": "BOOK-123-HC"
+                        },
+                        "perUnitDeclaredValue": {
+                          "currencyCode": "USD",
+                          "amount": "14.99"
+                        }
+                      },
+                      "amount": {
+                        "unit": "EACHES",
+                        "value": "1.0"
+                      },
+                      "cancelledAmount": {
+                        "unit": "EACHES",
+                        "value": "0"
+                      },
+                      "unfulfillableAmount": {
+                        "unit": "EACHES",
+                        "value": "0"
+                      },
+                      "services": {
+                        "packaging": {
+                          "packingSlip": {
+                            "templateName": "templateName",
+                            "templateAttributes": {
+                              "attributeName1": "attributeValue1",
+                              "attributeName2": "attributeValue2"
+                            }
+                          }
+                        },
+                        "delivery": {
+                          "paymentOnDelivery": {
+                            "perUnitServicePrice": {
+                              "currencyCode": "USD",
+                              "amount": "14.99"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "400": {
+            "description": "Request has missing or invalid parameters and cannot be parsed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "401": {
+            "description": "The request's Authorization header is not formatted correctly or does not contain a valid token.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "403": {
+            "description": "Indicates that access to the resource is forbidden. Possible reasons include Access Denied, Unauthorized, Expired Token, or Invalid Signature.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "404": {
+            "description": "The resource specified does not exist.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "413": {
+            "description": "The request size exceeded the maximum accepted size.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "415": {
+            "description": "The request payload is in an unsupported format.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "429": {
+            "description": "The frequency of requests was greater than allowed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected condition occurred that prevented the server from fulfilling the request.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "503": {
+            "description": "Temporary overloading or maintenance of the server.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fulfillment/outbound/2025-09-24/services": {
+      "x-amzn-api-sandbox": {
+        "dynamic": {}
+      },
+      "post": {
+        "tags": ["FulfillmentService"],
+        "description": "Creates a fulfillment service for the provided merchant with your specified preferences.\n\n**Usage Plan:**\n\n| Rate (requests per second) | Burst |\n| ---- | ---- |\n| 2 | 30 |\n\nFor more information, see \\\"Usage Plans and Rate Limits\\\" in the Selling Partner API documentation.",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "operationId": "createFulfillmentService",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateFulfillmentServiceRequest"
+            },
+            "description": "The request body that specifies fulfillment service values.",
+            "x-examples": {
+              "application/json": {
+                "fulfillmentService": {
+                  "merchantAccountId": "amzn1.merchant.o.A3SR1GB2AWB5VA",
+                  "displayName": "First Channel",
+                  "description": "First description",
+                  "defaultFulfillmentSettings": {
+                    "services": {
+                      "packaging": {
+                        "blankBox": "REQUIRED",
+                        "packingSlip": {
+                          "template": "Packing template"
+                        }
+                      },
+                      "delivery": {
+                        "deliverTogether": "REQUIRED",
+                        "signatureOnDelivery": "REQUIRED"
+                      },
+                      "additionalServices": {
+                        "serviceName": "REQUIRED"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/CreateFulfillmentServiceResponse"
+            },
+            "examples": {
+              "application/json": {
+                "id": "FS01-o8vlfw8b1tiu1",
+                "status": "ACTIVE"
+              }
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "400": {
+            "description": "Request has missing or invalid parameters and cannot be parsed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "401": {
+            "description": "The request's Authorization header is not formatted correctly or does not contain a valid token.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "403": {
+            "description": "Indicates that access to the resource is forbidden. Possible reasons include Access Denied, Unauthorized, Expired Token, or Invalid Signature.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "404": {
+            "description": "The resource specified does not exist.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "413": {
+            "description": "The request size exceeded the maximum accepted size.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "415": {
+            "description": "The request payload is in an unsupported format.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "429": {
+            "description": "The frequency of requests was greater than allowed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected condition occurred that prevented the server from fulfilling the request.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "503": {
+            "description": "Temporary overloading or maintenance of the server.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["FulfillmentService"],
+        "description": "List all fulfillment services.\n\n**Usage Plan:**\n\n| Rate (requests per second) | Burst |\n| ---- | ---- |\n| 2 | 30 |\n\nFor more information, see \\\"Usage Plans and Rate Limits\\\" in the Selling Partner API documentation.",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "operationId": "listFulfillmentServices",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "pageToken",
+            "required": false,
+            "description": "A token to fetch a certain page when there are multiple pages worth of results.",
+            "type": "string",
+            "x-example": "someToken"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/ListFulfillmentServicesResponse"
+            },
+            "examples": {
+              "application/json": {
+                "fulfillmentServices": [
+                  {
+                    "id": "FS01-o8vlfw8b1tiu1",
+                    "displayName": "First Channel",
+                    "description": "First description",
+                    "merchantAccountId": "amzn1.merchant.o.A3SR1GB2AWB5VA",
+                    "status": "ACTIVE",
+                    "defaultFulfillmentSettings": {
+                      "services": {
+                        "packaging": {
+                          "blankBox": "REQUIRED",
+                          "packingSlip": {
+                            "template": "Packing template"
+                          }
+                        },
+                        "delivery": {
+                          "deliverTogether": "REQUIRED",
+                          "signatureOnDelivery": "REQUIRED"
+                        },
+                        "additionalServices": {
+                          "serviceName": "REQUIRED"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "id": "0uykurg8",
+                    "displayName": "Second Channel",
+                    "merchantAccountId": "A3SR1GB2AWB5VB",
+                    "status": "ACTIVE",
+                    "defaultFulfillmentSettings": {
+                      "services": {
+                        "packaging": {
+                          "blankBox": "NOT_REQUIRED",
+                          "packingSlip": {
+                            "template": "Packing template"
+                          }
+                        },
+                        "additionalServices": {
+                          "serviceName": "REQUIRED"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "400": {
+            "description": "Request has missing or invalid parameters and cannot be parsed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "401": {
+            "description": "The request's Authorization header is not formatted correctly or does not contain a valid token.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "403": {
+            "description": "Indicates that access to the resource is forbidden. Possible reasons include Access Denied, Unauthorized, Expired Token, or Invalid Signature.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "404": {
+            "description": "The resource specified does not exist.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "413": {
+            "description": "The request size exceeded the maximum accepted size.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "415": {
+            "description": "The request payload is in an unsupported format.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "429": {
+            "description": "The frequency of requests was greater than allowed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected condition occurred that prevented the server from fulfilling the request.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "503": {
+            "description": "Temporary overloading or maintenance of the server.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fulfillment/outbound/2025-09-24/services/{id}": {
+      "x-amzn-api-sandbox": {
+        "dynamic": {}
+      },
+      "get": {
+        "tags": ["FulfillmentService"],
+        "description": "Get a fulfillment service.\n\n**Usage Plan:**\n\n| Rate (requests per second) | Burst |\n| ---- | ---- |\n| 2 | 30 |\n\nFor more information, see \\\"Usage Plans and Rate Limits\\\" in the Selling Partner API documentation.",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "operationId": "getFulfillmentService",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string",
+            "description": "The ID of the fulfillment service to retrieve.",
+            "x-example": "FS01-o8vlfw8b1tiu1"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/GetFulfillmentServiceResponse"
+            },
+            "examples": {
+              "application/json": {
+                "fulfillmentService": {
+                  "id": "FS01-o8vlfw8b1tiu1",
+                  "displayName": "First Channel",
+                  "description": "First description",
+                  "merchantAccountId": "amzn1.merchant.o.A3SR1GB2AWB5VA",
+                  "status": "ACTIVE",
+                  "defaultFulfillmentSettings": {
+                    "services": {
+                      "packaging": {
+                        "blankBox": "REQUIRED",
+                        "packingSlip": {
+                          "template": "Packing template"
+                        }
+                      },
+                      "delivery": {
+                        "deliverTogether": "REQUIRED",
+                        "signatureOnDelivery": "REQUIRED"
+                      },
+                      "additionalServices": {
+                        "serviceName": "REQUIRED"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "400": {
+            "description": "Request has missing or invalid parameters and cannot be parsed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "401": {
+            "description": "The request's Authorization header is not formatted correctly or does not contain a valid token.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "403": {
+            "description": "Indicates that access to the resource is forbidden. Possible reasons include Access Denied, Unauthorized, Expired Token, or Invalid Signature.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "404": {
+            "description": "The resource specified does not exist.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "413": {
+            "description": "The request size exceeded the maximum accepted size.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "415": {
+            "description": "The request payload is in an unsupported format.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "429": {
+            "description": "The frequency of requests was greater than allowed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected condition occurred that prevented the server from fulfilling the request.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "503": {
+            "description": "Temporary overloading or maintenance of the server.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["FulfillmentService"],
+        "description": "Update a fulfillment service.\n\n**Usage Plan:**\n\n| Rate (requests per second) | Burst |\n| ---- | ---- |\n| 2 | 30 |\n\nFor more information, see \\\"Usage Plans and Rate Limits\\\" in the Selling Partner API documentation.",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "operationId": "updateFulfillmentService",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateFulfillmentServiceRequest"
+            },
+            "description": "Updated fulfillment service parameters.",
+            "x-examples": {
+              "application/json": {
+                "fulfillmentService": {
+                  "displayName": "First Channel",
+                  "description": "First description",
+                  "status": "INACTIVE",
+                  "defaultFulfillmentSettings": {
+                    "services": {
+                      "packaging": {
+                        "blankBox": "REQUIRED",
+                        "packingSlip": {
+                          "template": "Packing template"
+                        }
+                      },
+                      "delivery": {
+                        "deliverTogether": "REQUIRED",
+                        "signatureOnDelivery": "REQUIRED"
+                      },
+                      "additionalServices": {
+                        "serviceName": "REQUIRED"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the fulfillment service to update.",
+            "x-example": "FS01-o8vlfw8b1tiu1",
+            "required": true,
+            "type": "string",
+            "maxLength": 40
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success.",
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "400": {
+            "description": "Request has missing or invalid parameters and cannot be parsed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "401": {
+            "description": "The request's Authorization header is not formatted correctly or does not contain a valid token.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "403": {
+            "description": "Indicates that access to the resource is forbidden. Possible reasons include Access Denied, Unauthorized, Expired Token, or Invalid Signature.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "404": {
+            "description": "The resource specified does not exist.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RateLimit-Limit": {
+                "type": "string",
+                "description": "Your rate limit (requests per second) for this operation."
+              },
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "413": {
+            "description": "The request size exceeded the maximum accepted size.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "415": {
+            "description": "The request payload is in an unsupported format.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "429": {
+            "description": "The frequency of requests was greater than allowed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected condition occurred that prevented the server from fulfilling the request.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          },
+          "503": {
+            "description": "Temporary overloading or maintenance of the server.",
+            "schema": {
+              "$ref": "#/definitions/ErrorList"
+            },
+            "headers": {
+              "x-amzn-RequestId": {
+                "type": "string",
+                "description": "Unique request reference identifier."
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Error": {
+      "type": "object",
+      "required": ["code", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "An error code that identifies the type of error that occurred."
+        },
+        "message": {
+          "type": "string",
+          "description": "A message that describes the error condition."
+        },
+        "details": {
+          "type": "string",
+          "description": "Additional details that can help the caller understand or fix the issue."
+        }
+      },
+      "description": "Error response returned when the request is unsuccessful."
+    },
+    "ErrorList": {
+      "type": "object",
+      "description": "A list of error responses returned when a request is unsuccessful.",
+      "required": ["errors"],
+      "properties": {
+        "errors": {
+          "type": "array",
+          "description": "array of errors",
+          "items": {
+            "$ref": "#/definitions/Error"
+          }
+        }
+      },
+      "example": {
+        "errors": [
+          {
+            "code": "InvalidParameterValue",
+            "message": "The value 'abc' is invalid for EmailAddress.",
+            "details": "The value 'abc' is invalid for EmailAddress."
+          }
+        ]
+      }
+    },
+    "Decimal": {
+      "type": "string",
+      "description": "A decimal number with no loss of precision. Useful when precision loss is unacceptable, as with currencies. Follows RFC7159 for number representation.",
+      "example": "1.0"
+    },
+    "Timestamp": {
+      "description": "Date timestamp in ISO 8601 date time format.",
+      "type": "string",
+      "format": "date-time",
+      "example": "2025-04-21T12:34:56Z"
+    },
+    "RollupPrice": {
+      "type": "object",
+      "required": ["type", "value"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of price."
+        },
+        "value": {
+          "$ref": "#/definitions/Money",
+          "description": "Total value for a price type."
+        }
+      },
+      "description": "A component of the total price.",
+      "example": {
+        "type": "MCFTransportationFee",
+        "value": {
+          "currencyCode": "USD",
+          "amount": "4.25"
+        }
+      }
+    },
+    "EstimatedPrice": {
+      "type": "object",
+      "required": ["rollupPrices", "totalPrice"],
+      "properties": {
+        "rollupPrices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RollupPrice"
+          },
+          "description": "Breakdown of the price associated with the delivery preview."
+        },
+        "totalPrice": {
+          "$ref": "#/definitions/Money",
+          "description": "Represents the total price associated with the delivery preview."
+        }
+      },
+      "description": "The estimated price information for the fulfillment order.",
+      "example": {
+        "rollupPrices": [
+          {
+            "type": "MCFTransportationFee",
+            "value": {
+              "currencyCode": "USD",
+              "amount": "4.25"
+            }
+          }
+        ],
+        "totalPrice": {
+          "currencyCode": "USD",
+          "amount": "4.25"
+        }
+      }
+    },
+    "GetOffersOrigin": {
+      "type": "object",
+      "required": ["countryCode"],
+      "properties": {
+        "countryCode": {
+          "$ref": "#/definitions/CountryCode",
+          "description": "The two-digit country code (in ISO 3166-1 alpha-2 format) for the country where the items will ship from."
+        }
+      },
+      "description": "The origin for the fulfillment.",
+      "example": {
+        "countryCode": "US"
+      }
+    },
+    "GetOrderPreviewOrigin": {
+      "type": "object",
+      "required": ["countryCode"],
+      "properties": {
+        "countryCode": {
+          "$ref": "#/definitions/CountryCode",
+          "description": "The two letter country code. In ISO 3166-1 alpha-2 format."
+        }
+      },
+      "description": "The origin for the fulfillment.",
+      "example": {
+        "countryCode": "US"
+      }
+    },
+    "GetOffersDestination": {
+      "type": "object",
+      "properties": {
+        "deliveryAddress": {
+          "$ref": "#/definitions/VariablePrecisionAddress"
+        },
+        "ipAddress": {
+          "$ref": "#/definitions/IpAddress",
+          "description": "The IP address of the customer."
+        }
+      },
+      "description": "The destination for the fulfillment.",
+      "example": {
+        "ipAddress": "192.168.0.1",
+        "deliveryAddress": {
+          "addressLine1": "1000 Winthrop Ave N",
+          "addressLine2": "Floor 19",
+          "addressLine3": "ATTN: Shopper",
+          "city": "Seattle",
+          "districtOrCounty": "None",
+          "countryCode": "US",
+          "postalCode": "98103",
+          "stateOrRegion": "WA"
+        }
+      }
+    },
+    "GetOrderPreviewDestination": {
+      "type": "object",
+      "required": ["deliveryAddress"],
+      "properties": {
+        "deliveryAddress": {
+          "$ref": "#/definitions/Address"
+        }
+      },
+      "description": "The destination for the fulfillment.",
+      "example": {
+        "deliveryAddress": {
+          "name": "Shopper Name",
+          "addressLine1": "1000 Winthrop Ave N",
+          "addressLine2": "Floor 19",
+          "addressLine3": "ATTN: Shopper",
+          "city": "Seattle",
+          "districtOrCounty": "None",
+          "countryCode": "US",
+          "phone": "123-456-7890",
+          "postalCode": "98103",
+          "stateOrRegion": "WA",
+          "email": "shopper@email.com"
+        }
+      }
+    },
+    "GetOrderPreviewRequest": {
+      "type": "object",
+      "required": ["destination", "lineItems"],
+      "properties": {
+        "deliveryServiceLevels": {
+          "type": "array",
+          "description": "A list of delivery speeds to request fulfillment preview information for. Possible values: STANDARD, EXPEDITED, PRIORITY, SCHEDULED.",
+          "items": {
+            "$ref": "#/definitions/DeliveryServiceLevel"
+          }
+        },
+        "destination": {
+          "$ref": "#/definitions/GetOrderPreviewDestination",
+          "description": "The destination for the fulfillment."
+        },
+        "origin": {
+          "$ref": "#/definitions/GetOrderPreviewOrigin",
+          "description": "The origin for the fulfillment preview."
+        },
+        "services": {
+          "$ref": "#/definitions/GetOrderPreviewServices",
+          "description": "Services selected for preview."
+        },
+        "lineItems": {
+          "type": "array",
+          "description": "A list of items to include in the fulfillment preview, including quantity.",
+          "items": {
+            "$ref": "#/definitions/GetOrderPreviewLineItem"
+          }
+        },
+        "excludeEstimatedFees": {
+          "type": "boolean",
+          "description": "When true, excludes estimated fees from the preview response for latency optimization. When false or not provided, includes rich data with estimated fees. Default: false."
+        }
+      },
+      "description": "The request body schema for the GetOrderPreview operation.",
+      "example": {
+        "deliveryServiceLevels": ["STANDARD"],
+        "origin": {
+          "countryCode": "US"
+        },
+        "destination": {
+          "deliveryAddress": {
+            "name": "Shopper Name",
+            "addressLine1": "1000 Winthrop Ave N",
+            "addressLine2": "Floor 19",
+            "addressLine3": "ATTN: Shopper",
+            "city": "Seattle",
+            "districtOrCounty": "None",
+            "countryCode": "US",
+            "phone": "123-456-7890",
+            "postalCode": "98103",
+            "stateOrRegion": "WA",
+            "email": "shopper@email.com"
+          }
+        },
+        "services": {
+          "packaging": {
+            "blankBox": "REQUIRED"
+          },
+          "delivery": {
+            "signatureOnDelivery": "ADULT_REQUIRED"
+          },
+          "additionalServices": {
+            "serviceName": "REQUIRED"
+          }
+        },
+        "lineItems": [
+          {
+            "product": {
+              "productIdentifier": {
+                "amazonSku": "someSku"
+              },
+              "perUnitDeclaredValue": {
+                "currencyCode": "USD",
+                "amount": "3.00"
+              }
+            },
+            "amount": {
+              "unit": "EACHES",
+              "value": "1.0"
+            }
+          }
+        ],
+        "excludeEstimatedFees": true
+      }
+    },
+    "CountryCode": {
+      "type": "string",
+      "description": "The two digit country code. In ISO 3166-1 alpha-2 format.",
+      "example": "US",
+      "minLength": 2,
+      "maxLength": 2
+    },
+    "Locale": {
+      "type": "string",
+      "description": "The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO 3166-1 alpha 2 code for the region in upper case; e.g. \"en\" for English, or \"en-US\" for American English versus \"en-EN\" for England English.",
+      "example": "en-US"
+    },
+    "DeliveryServiceLevel": {
+      "type": "string",
+      "description": "The shipping method for the offer. Possible values: STANDARD, EXPEDITED, PRIORITY, SCHEDULED.",
+      "example": "STANDARD",
+      "x-docgen-enum-table-extension": [
+        {
+          "value": "STANDARD",
+          "description": "Standard shipping method."
+        },
+        {
+          "value": "EXPEDITED",
+          "description": "Expedited shipping method."
+        },
+        {
+          "value": "PRIORITY",
+          "description": "Priority shipping method."
+        },
+        {
+          "value": "SCHEDULED",
+          "description": "SCHEDULED shipping method. Currently only available in Japan."
+        }
+      ]
+    },
+    "VariablePrecisionAddress": {
+      "type": "object",
+      "required": ["countryCode", "postalCode"],
+      "properties": {
+        "addressLine1": {
+          "type": "string",
+          "description": "The first line of the address."
+        },
+        "addressLine2": {
+          "type": "string",
+          "description": "Additional address information, if required."
+        },
+        "addressLine3": {
+          "type": "string",
+          "description": "Additional address information, if required."
+        },
+        "city": {
+          "type": "string",
+          "description": "The city where the person, business, or institution is located. This property should not be used in Japan."
+        },
+        "districtOrCounty": {
+          "type": "string",
+          "description": "The district or county where the person, business, or institution is located."
+        },
+        "stateOrRegion": {
+          "type": "string",
+          "description": "The state or region where the person, business or institution is located."
+        },
+        "postalCode": {
+          "type": "string",
+          "description": "The postal code of the address."
+        },
+        "countryCode": {
+          "$ref": "#/definitions/CountryCode",
+          "description": "The two-digit country code (in ISO 3166-1 alpha-2 format) for the country where the person, business or institution is located."
+        }
+      },
+      "description": "A physical address with varying degrees of precision. A more precise address can provide more accurate results than country code and postal code alone.",
+      "example": {
+        "addressLine1": "1000 Winthrop Ave N",
+        "addressLine2": "Floor 19",
+        "addressLine3": "ATTN: Shopper",
+        "city": "Seattle",
+        "districtOrCounty": "None",
+        "countryCode": "US",
+        "postalCode": "98103",
+        "stateOrRegion": "WA"
+      }
+    },
+    "Address": {
+      "type": "object",
+      "required": ["addressLine1", "countryCode", "name", "postalCode"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the person, business or institution at the address."
+        },
+        "addressLine1": {
+          "type": "string",
+          "description": "The first line of the address."
+        },
+        "addressLine2": {
+          "type": "string",
+          "description": "Additional address information, if required."
+        },
+        "addressLine3": {
+          "type": "string",
+          "description": "Additional address information, if required."
+        },
+        "city": {
+          "type": "string",
+          "description": "The city where the person, business, or institution is located. This property is required in all countries except Japan. It should not be used in Japan."
+        },
+        "districtOrCounty": {
+          "type": "string",
+          "description": "The district or county where the person, business, or institution is located."
+        },
+        "stateOrRegion": {
+          "type": "string",
+          "description": "The state or region where the person, business or institution is located."
+        },
+        "postalCode": {
+          "type": "string",
+          "description": "The postal code of the address."
+        },
+        "countryCode": {
+          "$ref": "#/definitions/CountryCode",
+          "description": "The two-digit country code (in ISO 3166-1 alpha-2 format) for the country where the person, business or institution is located."
+        },
+        "phone": {
+          "type": "string",
+          "description": "The phone number of the person, business, or institution located at the address."
+        },
+        "email": {
+          "type": "string",
+          "description": "The email of the person, business, or institution located at the address."
+        }
+      },
+      "description": "A physical address.",
+      "example": {
+        "name": "Shopper Name",
+        "addressLine1": "1000 Winthrop Ave N",
+        "addressLine2": "Floor 19",
+        "addressLine3": "ATTN: Shopper",
+        "city": "Seattle",
+        "districtOrCounty": "None",
+        "countryCode": "US",
+        "phone": "123-456-7890",
+        "postalCode": "98103",
+        "stateOrRegion": "WA",
+        "email": "shopper@email.com"
+      }
+    },
+    "IpAddress": {
+      "type": "string",
+      "format": "ip",
+      "description": "An IP address.",
+      "example": "192.168.0.1"
+    },
+    "GetOrderPreviewLineItem": {
+      "type": "object",
+      "required": ["product", "amount"],
+      "properties": {
+        "product": {
+          "$ref": "#/definitions/GetOrderPreviewProduct"
+        },
+        "amount": {
+          "$ref": "#/definitions/Amount"
+        }
+      },
+      "description": "Item information for a fulfillment preview.",
+      "example": {
+        "product": {
+          "productIdentifier": {
+            "amazonSku": "BOOK-123-HC"
+          },
+          "perUnitDeclaredValue": {
+            "currencyCode": "USD",
+            "amount": "14.99"
+          }
+        },
+        "amount": {
+          "unit": "EACHES",
+          "value": "2"
+        }
+      }
+    },
+    "GetOrderPreviewPlannedShipmentItem": {
+      "type": "object",
+      "required": ["productIdentifier", "amount"],
+      "properties": {
+        "productIdentifier": {
+          "$ref": "#/definitions/ProductIdentifier"
+        },
+        "amount": {
+          "$ref": "#/definitions/Amount"
+        }
+      },
+      "description": "Item information for a fulfillment preview.",
+      "example": {
+        "productIdentifier": {
+          "amazonSku": "BOOK-123-HC"
+        },
+        "amount": {
+          "unit": "EACHES",
+          "value": "2"
+        }
+      }
+    },
+    "GetOrderPreviewProduct": {
+      "type": "object",
+      "properties": {
+        "productIdentifier": {
+          "$ref": "#/definitions/ProductIdentifier"
+        },
+        "perUnitDeclaredValue": {
+          "$ref": "#/definitions/Money",
+          "description": "The monetary value assigned by the merchant to each unit."
+        }
+      },
+      "required": ["productIdentifier"],
+      "description": "Product information for the line item."
+    },
+    "OrderProduct": {
+      "type": "object",
+      "properties": {
+        "productIdentifier": {
+          "$ref": "#/definitions/ProductIdentifier"
+        },
+        "perUnitDeclaredValue": {
+          "$ref": "#/definitions/Money",
+          "description": "The monetary value assigned by the merchant to each unit."
+        }
+      },
+      "required": ["productIdentifier"],
+      "description": "Product information for the line item."
+    },
+    "ProductIdentifier": {
+      "type": "object",
+      "required": ["amazonSku"],
+      "properties": {
+        "amazonSku": {
+          "type": "string",
+          "description": "The merchant SKU of the item."
+        }
+      },
+      "description": "Identifies a product.",
+      "example": {
+        "amazonSku": "someSku"
+      }
+    },
+    "GetDeliveryOfferProduct": {
+      "type": "object",
+      "properties": {
+        "productIdentifier": {
+          "$ref": "#/definitions/ProductIdentifier"
+        }
+      },
+      "description": "Item information for an offer.",
+      "example": {
+        "product": {
+          "productIdentifier": {
+            "amazonSku": "someSku"
+          }
+        }
+      }
+    },
+    "Amount": {
+      "type": "object",
+      "required": ["value"],
+      "properties": {
+        "unit": {
+          "type": "string",
+          "description": "The unit of measure for the amount. Possible values: Eaches."
+        },
+        "value": {
+          "$ref": "#/definitions/Decimal",
+          "description": "The amount of a product in the associated unit of measurement."
+        }
+      },
+      "description": "A quantity based on the specified unit of measurement.",
+      "example": {
+        "unit": "EACHES",
+        "value": "1.0"
+      }
+    },
+    "Money": {
+      "type": "object",
+      "required": ["currencyCode", "amount"],
+      "properties": {
+        "currencyCode": {
+          "type": "string",
+          "description": "Three digit currency code in ISO 4217 format."
+        },
+        "amount": {
+          "$ref": "#/definitions/Decimal"
+        }
+      },
+      "description": "An amount of money, including units in the form of currency.",
+      "example": {
+        "currencyCode": "USD",
+        "amount": "2.50"
+      }
+    },
+    "GetOrderPreviewServices": {
+      "type": "object",
+      "properties": {
+        "packaging": {
+          "$ref": "#/definitions/PackagingService",
+          "description": "The packaging settings for the fulfillment preview."
+        },
+        "delivery": {
+          "$ref": "#/definitions/GetOrderPreviewDeliveryService",
+          "description": "Delivery service settings for the fulfillment preview."
+        },
+        "additionalServices": {
+          "$ref": "#/definitions/AdditionalServices",
+          "description": "Additional services for the fulfillment preview."
+        }
+      },
+      "description": "Services selected for a fulfillment preview.",
+      "example": {
+        "packaging": {
+          "blankBox": "REQUIRED"
+        },
+        "delivery": {
+          "signatureOnDelivery": "ADULT_REQUIRED"
+        },
+        "additionalServices": {
+          "serviceName": "REQUIRED"
+        }
+      }
+    },
+    "GetOrderPreviewDeliveryService": {
+      "type": "object",
+      "description": "Specify delivery service requirements.",
+      "properties": {
+        "signatureOnDelivery": {
+          "type": "string",
+          "description": "The signature requirement for delivery. Possible values: ADULT_REQUIRED, REQUIRED, NOT_REQUIRED.",
+          "enum": ["ADULT_REQUIRED", "REQUIRED", "NOT_REQUIRED"],
+          "x-docgen-enum-table-extension": [
+            {
+              "value": "ADULT_REQUIRED",
+              "description": "Signature of an adult is required on delivery."
+            },
+            {
+              "value": "REQUIRED",
+              "description": "Signature is required on delivery."
+            },
+            {
+              "value": "NOT_REQUIRED",
+              "description": "Signature is  NOT required on delivery."
+            }
+          ]
+        }
+      },
+      "example": {
+        "signatureOnDelivery": "ADULT_REQUIRED"
+      }
+    },
+    "PackagingService": {
+      "type": "object",
+      "description": "Specify packaging requirements.",
+      "properties": {
+        "blankBox": {
+          "type": "string",
+          "description": "The requirements for Blank Box."
+        },
+        "packingSlip": {
+          "$ref": "#/definitions/OrderPackingSlip",
+          "description": "Packing slip settings."
+        }
+      },
+      "example": {
+        "blankBox": "REQUIRED",
+        "packingSlip": {
+          "templateName": "templateName",
+          "templateAttributes": {
+            "attributeName1": "attributeValue1",
+            "attributeName2": "attributeValue2"
+          }
+        }
+      }
+    },
+    "DeliveryService": {
+      "type": "object",
+      "properties": {
+        "deliverTogether": {
+          "type": "string",
+          "description": "Whether items should be delivered together. Possible values: REQUIRED, NOT_REQUIRED.",
+          "enum": ["REQUIRED", "NOT_REQUIRED"],
+          "x-docgen-enum-table-extension": [
+            {
+              "value": "REQUIRED",
+              "description": "Items must be delivered together."
+            },
+            {
+              "value": "NOT_REQUIRED",
+              "description": "Items can be delivered separately."
+            }
+          ]
+        },
+        "signatureOnDelivery": {
+          "type": "string",
+          "description": "The signature requirement for delivery. Possible values: ADULT_REQUIRED, REQUIRED, NOT_REQUIRED.",
+          "enum": ["ADULT_REQUIRED", "REQUIRED", "NOT_REQUIRED"],
+          "x-docgen-enum-table-extension": [
+            {
+              "value": "ADULT_REQUIRED",
+              "description": "Signature of an adult is required on delivery."
+            },
+            {
+              "value": "REQUIRED",
+              "description": "Signature is required on delivery."
+            },
+            {
+              "value": "NOT_REQUIRED",
+              "description": "Signature is  NOT required on delivery."
+            }
+          ]
+        }
+      },
+      "description": "Specify delivery settings.",
+      "example": {
+        "signatureOnDelivery": "REQUIRED",
+        "deliverTogether": "REQUIRED"
+      }
+    },
+    "AdditionalServices": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Request additional services",
+      "example": {
+        "serviceName": "REQUIRED"
+      }
+    },
+    "GetOrderPreviewResponse": {
+      "type": "object",
+      "required": ["plannedShipments"],
+      "properties": {
+        "plannedShipments": {
+          "type": "array",
+          "description": "An array of planned shipment information.",
+          "items": {
+            "$ref": "#/definitions/GetOrderPreviewPlannedShipment"
+          }
+        },
+        "constraints": {
+          "type": "array",
+          "description": "An array of constraints that may affect the fulfillment order.",
+          "items": {
+            "$ref": "#/definitions/Constraint"
+          }
+        }
+      },
+      "description": "The response schema for the GetOrderPreview operation.",
+      "example": {
+        "plannedShipments": [
+          {
+            "estimatedShippingWeight": {
+              "unit": "KG",
+              "value": "2"
+            },
+            "items": [
+              {
+                "productIdentifier": {
+                  "amazonSku": "someSku"
+                },
+                "amount": {
+                  "unit": "EACHES",
+                  "value": "1.0"
+                }
+              }
+            ],
+            "services": {
+              "packaging": {
+                "blankBox": "REQUIRED"
+              },
+              "delivery": {
+                "signatureOnDelivery": "ADULT_REQUIRED"
+              },
+              "additionalServices": {
+                "serviceName": "REQUIRED"
+              }
+            },
+            "offers": [
+              {
+                "deliveryServiceLevel": "STANDARD",
+                "deliveryInterval": {
+                  "startTime": "2025-04-21T12:34:56Z",
+                  "endTime": "2025-04-22T12:34:56Z"
+                },
+                "estimatedPrice": {
+                  "rollupPrices": [
+                    {
+                      "type": "MCFTransportationFee",
+                      "value": {
+                        "currencyCode": "USD",
+                        "amount": "4.25"
+                      }
+                    }
+                  ],
+                  "totalPrice": {
+                    "currencyCode": "USD",
+                    "amount": "4.25"
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        "constraints": [
+          {
+            "message": "There is not enough quantity of item xyz.",
+            "type": "ValidationError",
+            "code": "ItemQuantityNotAvailable",
+            "details": [
+              {
+                "type": "someType",
+                "value": "someValue"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "GetOrderPreviewPlannedShipment": {
+      "type": "object",
+      "required": ["items"],
+      "properties": {
+        "estimatedShippingWeight": {
+          "$ref": "#/definitions/Weight",
+          "description": "The estimated shipping weight of the planned shipment."
+        },
+        "items": {
+          "type": "array",
+          "description": "The items in this planned shipment. These can be a subset of lineItems from the request depending on how shipments are planned.",
+          "items": {
+            "$ref": "#/definitions/GetOrderPreviewPlannedShipmentItem"
+          }
+        },
+        "services": {
+          "$ref": "#/definitions/GetOrderPreviewServices",
+          "description": "Services selected for planned shipment."
+        },
+        "offers": {
+          "type": "array",
+          "description": "An array of offers for this planned shipment.",
+          "items": {
+            "$ref": "#/definitions/GetOrderPreviewDeliveryOffer"
+          }
+        }
+      },
+      "description": "A group of items to be delivered together.",
+      "example": {
+        "estimatedShippingWeight": {
+          "unit": "KG",
+          "value": "2"
+        },
+        "items": [
+          {
+            "productIdentifier": {
+              "amazonSku": "someSku"
+            },
+            "amount": {
+              "unit": "EACHES",
+              "value": "1.0"
+            }
+          }
+        ],
+        "services": {
+          "packaging": {
+            "blankBox": "REQUIRED"
+          },
+          "delivery": {
+            "signatureOnDelivery": "ADULT_REQUIRED"
+          },
+          "additionalServices": {
+            "serviceName": "REQUIRED"
+          }
+        },
+        "offers": [
+          {
+            "deliveryServiceLevel": "STANDARD",
+            "deliveryInterval": {
+              "startTime": "2025-04-21T12:34:56Z",
+              "endTime": "2025-04-22T12:34:56Z"
+            },
+            "services": {
+              "packaging": {
+                "blankBox": "REQUIRED"
+              },
+              "delivery": {
+                "signatureOnDelivery": "ADULT_REQUIRED"
+              },
+              "additionalServices": {
+                "serviceName": "REQUIRED"
+              }
+            },
+            "estimatedPrice": {
+              "rollupPrices": [
+                {
+                  "type": "MCFTransportationFee",
+                  "value": {
+                    "currencyCode": "USD",
+                    "amount": "4.25"
+                  }
+                }
+              ],
+              "totalPrice": {
+                "currencyCode": "USD",
+                "amount": "4.25"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "Weight": {
+      "type": "object",
+      "required": ["unit", "value"],
+      "properties": {
+        "unit": {
+          "type": "string",
+          "description": "The unit of weight. Possible values: KG, KILOGRAMS, LB, POUNDS."
+        },
+        "value": {
+          "type": "string",
+          "description": "The weight value."
+        }
+      },
+      "description": "The weight.",
+      "example": {
+        "unit": "KG",
+        "value": "2"
+      }
+    },
+    "GetOrderPreviewDeliveryOffer": {
+      "type": "object",
+      "properties": {
+        "deliveryServiceLevel": {
+          "$ref": "#/definitions/DeliveryServiceLevel"
+        },
+        "deliveryInterval": {
+          "$ref": "#/definitions/TimeInterval"
+        },
+        "estimatedPrice": {
+          "description": "The estimated fees for the offer.",
+          "$ref": "#/definitions/EstimatedPrice"
+        }
+      },
+      "description": "An available offer for delivery of a group of items.",
+      "example": {
+        "deliveryServiceLevel": "STANDARD",
+        "deliveryInterval": {
+          "startTime": "2025-05-01T16:00:00Z",
+          "endTime": "2025-05-02T01:00:00Z"
+        },
+        "estimatedPrice": {
+          "rollupPrices": [
+            {
+              "type": "MCFTransportationFee",
+              "value": {
+                "currencyCode": "USD",
+                "amount": "4.25"
+              }
+            }
+          ],
+          "totalPrice": {
+            "currencyCode": "USD",
+            "amount": "4.25"
+          }
+        }
+      }
+    },
+    "TimeInterval": {
+      "type": "object",
+      "required": ["startTime", "endTime"],
+      "properties": {
+        "startTime": {
+          "$ref": "#/definitions/Timestamp",
+          "description": "The earliest point in a date range in ISO 8601 date time format."
+        },
+        "endTime": {
+          "$ref": "#/definitions/Timestamp",
+          "description": "The latest point in a date range in ISO 8601 date time format."
+        }
+      },
+      "description": "The time range within which something (e.g., a delivery) will occur.",
+      "example": {
+        "startTime": "2025-04-21T12:34:56Z",
+        "endTime": "2025-04-22T12:34:56Z"
+      }
+    },
+    "Constraint": {
+      "type": "object",
+      "required": ["message", "type", "code"],
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "A human-readable description of the constraint.",
+          "example": "The requested id is not available for purchase."
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of constraint.",
+          "example": "ValidationError"
+        },
+        "code": {
+          "type": "string",
+          "description": "The constraint code.",
+          "example": "ItemQuantityNotAvailable"
+        },
+        "details": {
+          "type": "array",
+          "description": "Array of constraint details",
+          "items": {
+            "$ref": "#/definitions/ConstraintDetail"
+          }
+        }
+      },
+      "description": "A constraint that may affect a fulfillment order.",
+      "example": {
+        "message": "There is not enough of quantity xyz.",
+        "type": "ValidationError",
+        "code": "ItemQuantityNotAvailable",
+        "details": [
+          {
+            "type": "someType",
+            "value": "someValue"
+          }
+        ]
+      }
+    },
+    "ConstraintDetail": {
+      "type": "object",
+      "description": "Additional information about a constraint violation, providing the specific type of detail and its corresponding value that caused the violation.",
+      "required": ["type", "value"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of the constraint detail.",
+          "example": "someDetail"
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the constraint detail.",
+          "example": "someValue"
+        }
+      },
+      "example": {
+        "type": "someType",
+        "value": "someValue"
+      }
+    },
+    "CreateOrderRequest": {
+      "type": "object",
+      "required": ["orderId", "destination", "lineItems"],
+      "properties": {
+        "orderId": {
+          "type": "string",
+          "description": "A fulfillment order identifier that the merchant creates to track their fulfillment order. The orderId must be unique for each fulfillment order that a merchant creates. If the merchant's system already creates unique order identifiers, then these might be good values for them to use.",
+          "example": "some-fulfillment-order-id"
+        },
+        "deliveryServiceLevel": {
+          "$ref": "#/definitions/DeliveryServiceLevel",
+          "description": "The delivery speed to be used to fulfill the order. Possible values: STANDARD, EXPEDITED, PRIORITY, SCHEDULED."
+        },
+        "fulfillmentAction": {
+          "$ref": "#/definitions/OrderFulfillmentAction",
+          "description": "Specifies whether the fulfillment order should ship now or have an order hold put on it. Possible values: HOLD, SHIP."
+        },
+        "fulfillmentPolicy": {
+          "$ref": "#/definitions/OrderFulfillmentPolicy",
+          "description": "The policy for the fulfillment order. Possible values: FILL_OR_KILL, FILL_ALL and FILL_ALL_AVAILABLE"
+        },
+        "destination": {
+          "$ref": "#/definitions/OrderDestination",
+          "description": "The destination for the fulfillment."
+        },
+        "origin": {
+          "$ref": "#/definitions/OrderOrigin",
+          "description": "The origin for the fulfillment order."
+        },
+        "services": {
+          "$ref": "#/definitions/OrderServices",
+          "description": "Services for the order."
+        },
+        "lineItems": {
+          "type": "array",
+          "description": "A list of items to include in the fulfillment order, including quantity.",
+          "items": {
+            "$ref": "#/definitions/OrderLineItem"
+          }
+        }
+      },
+      "description": "The request body schema for the createOrder operation.",
+      "example": {
+        "orderId": "someorderId",
+        "deliveryServiceLevel": "STANDARD",
+        "fulfillmentAction": "HOLD",
+        "fulfillmentPolicy": "FILL_ALL_AVAILABLE",
+        "origin": {
+          "countryCode": "US"
+        },
+        "destination": {
+          "deliveryAddress": {
+            "name": "Shopper Name",
+            "addressLine1": "1000 Winthrop Ave N",
+            "addressLine2": "Floor 19",
+            "addressLine3": "ATTN: Shopper",
+            "city": "Seattle",
+            "districtOrCounty": "None",
+            "countryCode": "US",
+            "phone": "123-456-7890",
+            "postalCode": "98103",
+            "stateOrRegion": "WA",
+            "email": "shopper@email.com"
+          }
+        },
+        "services": {
+          "packaging": {
+            "blankBox": "REQUIRED",
+            "packingSlip": {
+              "templateName": "templateName",
+              "templateAttributes": {
+                "attributeName1": "attributeValue1",
+                "attributeName2": "attributeValue2"
+              }
+            }
+          },
+          "additionalServices": {
+            "serviceName": "REQUIRED"
+          }
+        },
+        "lineItems": [
+          {
+            "lineItemId": "someLineItemId",
+            "product": {
+              "productIdentifier": {
+                "amazonSku": "BOOK-123-HC"
+              },
+              "perUnitDeclaredValue": {
+                "currencyCode": "USD",
+                "amount": "14.99"
+              }
+            },
+            "amount": {
+              "unit": "EACHES",
+              "value": "1.0"
+            },
+            "services": {
+              "packaging": {
+                "blankBox": "REQUIRED",
+                "packingSlip": {
+                  "templateName": "templateName",
+                  "templateAttributes": {
+                    "attributeName1": "attributeValue1",
+                    "attributeName2": "attributeValue2"
+                  }
+                },
+                "delivery": {
+                  "paymentOnDelivery": {
+                    "perUnitServicePrice": {
+                      "currencyCode": "USD",
+                      "amount": "14.99"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "CreateOrderResponse": {
+      "type": "object",
+      "required": ["fulfillmentOrder"],
+      "properties": {
+        "fulfillmentOrder": {
+          "$ref": "#/definitions/FulfillmentOrder"
+        }
+      },
+      "description": "The response schema for the `CreateOrder` operation.",
+      "example": {
+        "fulfillmentOrder": {
+          "deliveryServiceLevel": "STANDARD",
+          "orderId": "ABC123XYZ",
+          "receiveTime": "2025-04-21T10:30:00Z",
+          "status": "PROCESSING",
+          "fulfillmentAction": "HOLD",
+          "fulfillmentPolicy": "FILL_ALL_AVAILABLE",
+          "statusUpdateTime": "2025-04-21T11:45:00Z",
+          "origin": {
+            "countryCode": "US"
+          },
+          "destination": {
+            "deliveryAddress": {
+              "name": "Shopper Name",
+              "addressLine1": "1000 Winthrop Ave N",
+              "addressLine2": "Floor 19",
+              "addressLine3": "ATTN: Shopper",
+              "city": "Seattle",
+              "districtOrCounty": "None",
+              "countryCode": "US",
+              "phone": "123-456-7890",
+              "postalCode": "98103",
+              "stateOrRegion": "WA",
+              "email": "shopper@email.com"
+            },
+            "deliveryNotes": "Please beware of dogs.",
+            "dropOffLocation": {
+              "type": "FALLBACK_NEIGHBOR_DELIVERY",
+              "attributes": {
+                "neighborName": "neighborName",
+                "houseNumber": "houseNumber"
+              }
+            }
+          },
+          "services": {
+            "packaging": {
+              "blankBox": "REQUIRED",
+              "packingSlip": {
+                "templateName": "templateName",
+                "templateAttributes": {
+                  "attributeName1": "attributeValue1",
+                  "attributeName2": "attributeValue2"
+                }
+              }
+            },
+            "delivery": {
+              "signatureOnDelivery": "REQUIRED",
+              "deliverTogether": "REQUIRED"
+            },
+            "additionalServices": {
+              "serviceName": "REQUIRED"
+            }
+          },
+          "lineItems": [
+            {
+              "lineItemId": "someLineItemId",
+              "product": {
+                "productIdentifier": {
+                  "amazonSku": "BOOK-123-HC"
+                },
+                "perUnitDeclaredValue": {
+                  "currencyCode": "USD",
+                  "amount": "14.99"
+                }
+              },
+              "amount": {
+                "unit": "EACHES",
+                "value": "1.0"
+              },
+              "cancelledAmount": {
+                "unit": "EACHES",
+                "value": "0"
+              },
+              "unfulfillableAmount": {
+                "unit": "EACHES",
+                "value": "0"
+              },
+              "services": {
+                "packaging": {
+                  "packingSlip": {
+                    "templateName": "templateName",
+                    "templateAttributes": {
+                      "attributeName1": "attributeValue1",
+                      "attributeName2": "attributeValue2"
+                    }
+                  }
+                },
+                "delivery": {
+                  "paymentOnDelivery": {
+                    "perUnitServicePrice": {
+                      "currencyCode": "USD",
+                      "amount": "14.99"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "OrderServices": {
+      "type": "object",
+      "properties": {
+        "packaging": {
+          "$ref": "#/definitions/PackagingService",
+          "description": "The packaging settings for the fulfillment order."
+        },
+        "delivery": {
+          "$ref": "#/definitions/DeliveryService",
+          "description": "Delivery settings for the fulfillment order."
+        },
+        "additionalServices": {
+          "$ref": "#/definitions/AdditionalServices",
+          "description": "Additional services for the fulfillment order."
+        }
+      },
+      "description": "Services selected for a fulfillment order.",
+      "example": {
+        "packaging": {
+          "blankBox": "REQUIRED",
+          "packingSlip": {
+            "templateName": "templateName",
+            "templateAttributes": {
+              "attributeName1": "attributeValue1",
+              "attributeName2": "attributeValue2"
+            }
+          }
+        },
+        "delivery": {
+          "signatureOnDelivery": "ADULT_REQUIRED"
+        },
+        "additionalServices": {
+          "serviceName": "REQUIRED"
+        }
+      }
+    },
+    "OrderLineItem": {
+      "type": "object",
+      "required": ["lineItemId", "product", "amount"],
+      "properties": {
+        "lineItemId": {
+          "type": "string",
+          "description": "The line item identifier for the fulfillment order.",
+          "example": "someLineItemId"
+        },
+        "product": {
+          "$ref": "#/definitions/OrderProduct"
+        },
+        "amount": {
+          "$ref": "#/definitions/Amount"
+        },
+        "cancelledAmount": {
+          "$ref": "#/definitions/Amount"
+        },
+        "unfulfillableAmount": {
+          "$ref": "#/definitions/Amount"
+        },
+        "perUnitDeclaredValue": {
+          "$ref": "#/definitions/Money",
+          "description": "The monetary value assigned by the merchant to each unit."
+        },
+        "services": {
+          "$ref": "#/definitions/OrderLineItemServices",
+          "description": "Services selected for the line item."
+        }
+      },
+      "description": "Line Item information for a fulfillment order.",
+      "example": {
+        "lineItemId": "someLineItemId",
+        "product": {
+          "productIdentifier": {
+            "amazonSku": "BOOK-123-HC"
+          },
+          "perUnitDeclaredValue": {
+            "currencyCode": "USD",
+            "amount": "14.99"
+          }
+        },
+        "amount": {
+          "unit": "EACHES",
+          "value": "1.0"
+        },
+        "services": {
+          "packaging": {
+            "packingSlip": {
+              "templateName": "templateName",
+              "templateAttributes": {
+                "attributeName1": "attributeValue1",
+                "attributeName2": "attributeValue2"
+              }
+            }
+          },
+          "delivery": {
+            "paymentOnDelivery": {
+              "perUnitServicePrice": {
+                "currencyCode": "USD",
+                "amount": "14.99"
+              }
+            }
+          }
+        }
+      }
+    },
+    "OrderOrigin": {
+      "type": "object",
+      "required": ["countryCode"],
+      "properties": {
+        "countryCode": {
+          "$ref": "#/definitions/CountryCode",
+          "description": "The two-digit country code (in ISO 3166-1 alpha-2 format) for the country where the items will ship from."
+        }
+      },
+      "description": "The origin for the fulfillment.",
+      "example": {
+        "countryCode": "US"
+      }
+    },
+    "OrderDestination": {
+      "type": "object",
+      "required": ["deliveryAddress"],
+      "properties": {
+        "deliveryAddress": {
+          "$ref": "#/definitions/Address"
+        },
+        "deliveryNotes": {
+          "type": "string",
+          "description": "Delivery notes for the fulfillment order.",
+          "example": "Please beware of dogs."
+        },
+        "dropOffLocation": {
+          "description": "Drop-off location for the fulfillment order.",
+          "$ref": "#/definitions/OrderDropOffLocation"
+        }
+      },
+      "description": "The destination for the fulfillment order.",
+      "example": {
+        "deliveryAddress": {
+          "name": "Shopper Name",
+          "addressLine1": "1000 Winthrop Ave N",
+          "addressLine2": "Floor 19",
+          "addressLine3": "ATTN: Shopper",
+          "city": "Seattle",
+          "districtOrCounty": "None",
+          "countryCode": "US",
+          "phone": "123-456-7890",
+          "postalCode": "98103",
+          "stateOrRegion": "WA",
+          "email": "shopper@email.com"
+        },
+        "deliveryNotes": "Please beware of dogs.",
+        "dropOffLocation": {
+          "type": "FALLBACK_NEIGHBOR_DELIVERY",
+          "attributes": {
+            "neighborName": "neighborName",
+            "houseNumber": "houseNumber"
+          }
+        }
+      }
+    },
+    "OrderPackingSlip": {
+      "type": "object",
+      "properties": {
+        "templateName": {
+          "type": "string",
+          "description": "The template name for the packing slip.",
+          "example": "templateName"
+        },
+        "templateAttributes": {
+          "$ref": "#/definitions/OrderPackingSlipTemplateAttributes"
+        }
+      },
+      "example": {
+        "templateName": "templateName",
+        "templateAttributes": {
+          "attributeName1": "attributeValue1",
+          "attributeName2": "attributeValue2"
+        }
+      },
+      "description": "Packing slip settings."
+    },
+    "OrderPackingSlipTemplateAttributes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Packing slip template attributes.",
+      "example": {
+        "attributeName1": "attributeValue1",
+        "attributeName2": "attributeValue2"
+      }
+    },
+    "OrderLineItemPaymentOnDelivery": {
+      "type": "object",
+      "properties": {
+        "perUnitServicePrice": {
+          "$ref": "#/definitions/Money"
+        }
+      },
+      "example": {
+        "perUnitServicePrice": {
+          "currencyCode": "USD",
+          "amount": "14.99"
+        }
+      },
+      "description": "Payment on delivery settings. Currently only available in India."
+    },
+    "OrderDropOffLocation": {
+      "type": "object",
+      "description": "Drop-off location for the fulfillment order.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/OrderDropOffLocationType",
+          "description": "Specifies the preferred location to leave the package at the destination address. Possible values: FRONT_DOOR, DELIVERY_BOX, GAS_METER_BOX, BICYCLE_BASKET, GARAGE, RECEPTIONIST, FALLBACK_NEIGHBOR_DELIVERY, DO_NOT_LEAVE_UNATTENDED"
+        },
+        "attributes": {
+          "$ref": "#/definitions/OrderDropOffLocationAttributes",
+          "description": "Drop-off location attributes."
+        }
+      },
+      "example": {
+        "type": "FALLBACK_NEIGHBOR_DELIVERY",
+        "attributes": {
+          "neighborName": "neighborName",
+          "houseNumber": "houseNumber"
+        }
+      }
+    },
+    "OrderDropOffLocationAttributes": {
+      "type": "object",
+      "additionalProperties": {},
+      "description": "Drop-off location attributes."
+    },
+    "OrderDropOffLocationType": {
+      "type": "string",
+      "description": "Specifies the preferred location to leave the package at the destination address.",
+      "x-docgen-enum-table-extension": [
+        {
+          "value": "FRONT_DOOR",
+          "description": "Indicates delivery preferred to front door."
+        },
+        {
+          "value": "DELIVERY_BOX",
+          "description": "Indicates delivery preferred to a delivery box."
+        },
+        {
+          "value": "GAS_METER_BOX",
+          "description": "Indicates delivery preferred to a gas meter box."
+        },
+        {
+          "value": "BICYCLE_BASKET",
+          "description": "Indicates delivery preferred to a bicycle basket."
+        },
+        {
+          "value": "GARAGE",
+          "description": "Indicates delivery preferred to a garage."
+        },
+        {
+          "value": "RECEPTIONIST",
+          "description": "Indicates delivery preferred with a receptionist."
+        },
+        {
+          "value": "FALLBACK_NEIGHBOR_DELIVERY",
+          "description": "Indicates delivery preferred with a designated neighbor if the recipient is not available at the destination address."
+        },
+        {
+          "value": "DO_NOT_LEAVE_UNATTENDED",
+          "description": "Indicates delivery preferred as attended."
+        }
+      ]
+    },
+    "OrderLineItemServices": {
+      "type": "object",
+      "properties": {
+        "packaging": {
+          "$ref": "#/definitions/OrderLineItemPackagingService"
+        },
+        "delivery": {
+          "$ref": "#/definitions/OrderLineItemDeliveryService"
+        }
+      },
+      "description": "Services selected for a line item.",
+      "example": {
+        "packaging": {
+          "packingSlip": {
+            "templateName": "templateName",
+            "templateAttributes": {
+              "attributeName1": "attributeValue1",
+              "attributeName2": "attributeValue2"
+            }
+          }
+        },
+        "delivery": {
+          "paymentOnDelivery": {
+            "perUnitServicePrice": {
+              "currencyCode": "USD",
+              "amount": "14.99"
+            }
+          }
+        }
+      }
+    },
+    "OrderLineItemPackagingService": {
+      "type": "object",
+      "properties": {
+        "packingSlip": {
+          "$ref": "#/definitions/OrderPackingSlip",
+          "description": "Line item packing slip settings."
+        }
+      },
+      "description": "Packaging settings for the line item."
+    },
+    "OrderLineItemDeliveryService": {
+      "type": "object",
+      "properties": {
+        "paymentOnDelivery": {
+          "$ref": "#/definitions/OrderLineItemPaymentOnDelivery",
+          "description": "Payment On Delivery costs."
+        }
+      },
+      "description": "Delivery settings for the line item."
+    },
+    "OrderFulfillmentAction": {
+      "type": "string",
+      "description": "Specifies whether the fulfillment order should ship now or have an order hold put on it.",
+      "x-docgen-enum-table-extension": [
+        {
+          "value": "SHIP",
+          "description": "Default value. The fulfillment order ships now."
+        },
+        {
+          "value": "HOLD",
+          "description": "An order hold is put on the fulfillment order."
+        }
+      ],
+      "example": "HOLD"
+    },
+    "OrderFulfillmentPolicy": {
+      "type": "string",
+      "description": "The policy value specified when you submitted the createOrder operation.",
+      "x-docgen-enum-table-extension": [
+        {
+          "value": "FILL_OR_KILL",
+          "description": "Default value. If an item in a fulfillment order is determined to be unfulfillable before any shipment in the order has acquired the status of Processing (the process of picking units from inventory has begun), then the entire order is considered unfulfillable. However, if an item in a fulfillment order is determined to be unfulfillable after a shipment in the order has acquired the status of Processing, Amazon cancels as much of the fulfillment order as possible. See the Shipment object for shipment status definitions."
+        },
+        {
+          "value": "FILL_ALL",
+          "description": "All fulfillable items in the fulfillment order are shipped. The fulfillment order remains in a processing state until all items are either shipped by Amazon or cancelled by the merchant."
+        },
+        {
+          "value": "FILL_ALL_AVAILABLE",
+          "description": "All fulfillable items in the fulfillment order are shipped. All unfulfillable items in the order are cancelled."
+        }
+      ]
+    },
+    "GetOffersRequest": {
+      "type": "object",
+      "required": ["product", "amount", "origin"],
+      "properties": {
+        "product": {
+          "$ref": "#/definitions/GetDeliveryOfferProduct"
+        },
+        "amount": {
+          "$ref": "#/definitions/Amount"
+        },
+        "origin": {
+          "$ref": "#/definitions/GetOffersOrigin"
+        },
+        "destination": {
+          "$ref": "#/definitions/GetOffersDestination"
+        }
+      },
+      "description": "The request body schema for the getOffers operation.",
+      "example": {
+        "product": {
+          "productIdentifier": {
+            "amazonSku": "someSku"
+          }
+        },
+        "amount": {
+          "unit": "EACHES",
+          "value": "1.0"
+        },
+        "origin": {
+          "countryCode": "US"
+        },
+        "destination": {
+          "ipAddress": "192.168.0.1",
+          "deliveryAddress": {
+            "addressLine1": "1000 Winthrop Ave N",
+            "addressLine2": "Floor 19",
+            "addressLine3": "ATTN: Shopper",
+            "city": "Seattle",
+            "districtOrCounty": "None",
+            "countryCode": "US",
+            "postalCode": "98103",
+            "stateOrRegion": "WA"
+          }
+        }
+      }
+    },
+    "GetOffersResponse": {
+      "type": "object",
+      "properties": {
+        "offers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GetOffersOffer"
+          },
+          "description": "A list of offers, including offer expiration, earliest and latest date and time range, and the offer policy."
+        }
+      },
+      "description": "The response schema for the getOffers operation.",
+      "example": {
+        "offers": [
+          {
+            "deliveryInterval": {
+              "startTime": "2025-04-25T18:59:00Z",
+              "endTime": "2025-04-25T18:59:00Z"
+            },
+            "expiryTime": "2025-04-24T20:39:59Z",
+            "policy": {
+              "messaging": {
+                "locale": "en-US",
+                "text": "Get it as soon as Tomorrow Apr 25"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "GetOffersOffer": {
+      "type": "object",
+      "properties": {
+        "expiryTime": {
+          "$ref": "#/definitions/Timestamp",
+          "description": "The timestamp at which an offer expires."
+        },
+        "deliveryInterval": {
+          "$ref": "#/definitions/TimeInterval",
+          "description": "The range between which delivery is expected."
+        },
+        "policy": {
+          "$ref": "#/definitions/GetOffersDeliveryPolicy",
+          "description": "The policy for an offer, including localized messaging."
+        }
+      },
+      "description": "An available offer for delivery of a product.",
+      "example": {
+        "deliveryInterval": {
+          "startTime": "2025-04-25T18:59:00Z",
+          "endTime": "2025-04-25T18:59:00Z"
+        },
+        "expiryTime": "2025-04-24T20:39:59Z",
+        "policy": {
+          "messaging": {
+            "locale": "en-US",
+            "text": "Get it as soon as Tomorrow Apr 25"
+          }
+        }
+      }
+    },
+    "GetOffersDeliveryPolicy": {
+      "type": "object",
+      "properties": {
+        "messaging": {
+          "$ref": "#/definitions/GetOffersDeliveryMessage",
+          "description": "Localized messaging for an offer."
+        }
+      },
+      "description": "The policy for an offer.",
+      "example": {
+        "messaging": {
+          "locale": "en-US",
+          "text": "Get it as soon as Tomorrow Apr 25"
+        }
+      }
+    },
+    "GetOffersDeliveryMessage": {
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "The message content for an offer."
+        },
+        "locale": {
+          "$ref": "#/definitions/Locale",
+          "description": "The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO 3166-1 alpha 2 code for the region in upper case; e.g. \"en\" for English, or \"en-US\" for American English versus \"en-EN\" for England English."
+        }
+      },
+      "description": "Localized messaging for an offer.",
+      "example": {
+        "locale": "en-US",
+        "text": "Get it as soon as Tomorrow Apr 25"
+      }
+    },
+    "UpdateOrderRequest": {
+      "type": "object",
+      "required": ["fulfillmentAction"],
+      "properties": {
+        "fulfillmentAction": {
+          "$ref": "#/definitions/OrderFulfillmentAction",
+          "description": "Specifies whether the fulfillment order should ship now or have an order hold put on it. Possible values: HOLD, SHIP."
+        }
+      },
+      "description": "The request body schema for the updateOrder operation.",
+      "example": {
+        "fulfillmentAction": "SHIP"
+      }
+    },
+    "OrderStatus": {
+      "type": "string",
+      "description": "The current status of the fulfillment order. Possible values are PROCESSING, COMPLETE, COMPLETE_PARTIAL, UNFULFILLABLE.",
+      "example": "PROCESSING"
+    },
+    "GetOrderResponse": {
+      "type": "object",
+      "required": ["fulfillmentOrder"],
+      "properties": {
+        "fulfillmentOrder": {
+          "$ref": "#/definitions/FulfillmentOrder"
+        }
+      },
+      "description": "The response schema for the `GetOrder` operation.",
+      "example": {
+        "fulfillmentOrder": {
+          "deliveryServiceLevel": "STANDARD",
+          "orderId": "ABC123XYZ",
+          "receiveTime": "2025-04-21T10:30:00Z",
+          "status": "PROCESSING",
+          "fulfillmentAction": "HOLD",
+          "fulfillmentPolicy": "FILL_ALL_AVAILABLE",
+          "statusUpdateTime": "2025-04-21T11:45:00Z",
+          "origin": {
+            "countryCode": "US"
+          },
+          "destination": {
+            "deliveryAddress": {
+              "name": "Shopper Name",
+              "addressLine1": "1000 Winthrop Ave N",
+              "addressLine2": "Floor 19",
+              "addressLine3": "ATTN: Shopper",
+              "city": "Seattle",
+              "districtOrCounty": "None",
+              "countryCode": "US",
+              "phone": "123-456-7890",
+              "postalCode": "98103",
+              "stateOrRegion": "WA",
+              "email": "shopper@email.com"
+            },
+            "deliveryNotes": "Please beware of dogs.",
+            "dropOffLocation": {
+              "type": "FALLBACK_NEIGHBOR_DELIVERY",
+              "attributes": {
+                "neighborName": "neighborName",
+                "houseNumber": "houseNumber"
+              }
+            }
+          },
+          "services": {
+            "packaging": {
+              "blankBox": "REQUIRED",
+              "packingSlip": {
+                "templateName": "templateName",
+                "templateAttributes": {
+                  "attributeName1": "attributeValue1",
+                  "attributeName2": "attributeValue2"
+                }
+              }
+            },
+            "delivery": {
+              "signatureOnDelivery": "REQUIRED",
+              "deliverTogether": "REQUIRED"
+            },
+            "additionalServices": {
+              "serviceName": "REQUIRED"
+            }
+          },
+          "lineItems": [
+            {
+              "lineItemId": "someLineItemId",
+              "product": {
+                "productIdentifier": {
+                  "amazonSku": "BOOK-123-HC"
+                },
+                "perUnitDeclaredValue": {
+                  "currencyCode": "USD",
+                  "amount": "14.99"
+                }
+              },
+              "amount": {
+                "unit": "EACHES",
+                "value": "1.0"
+              },
+              "cancelledAmount": {
+                "unit": "EACHES",
+                "value": "0"
+              },
+              "unfulfillableAmount": {
+                "unit": "EACHES",
+                "value": "0"
+              },
+              "services": {
+                "packaging": {
+                  "packingSlip": {
+                    "templateName": "templateName",
+                    "templateAttributes": {
+                      "attributeName1": "attributeValue1",
+                      "attributeName2": "attributeValue2"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "shipments": [
+            {
+              "amazonShipmentId": "SHIP901234",
+              "fulfillmentCenter": {
+                "id": "FC456",
+                "address": {
+                  "name": "FC456",
+                  "addressLine1": "940 W Bethel Road",
+                  "city": "Coppell",
+                  "stateOrRegion": "TX",
+                  "postalCode": "75019-4424",
+                  "countryCode": "US"
+                }
+              },
+              "status": "SHIPPED",
+              "shipTime": "2025-04-21T15:00:00Z",
+              "deliveryTime": "2025-04-23T12:00:00Z",
+              "items": [
+                {
+                  "productIdentifier": {
+                    "amazonSku": "SKU123"
+                  },
+                  "lineItemId": "LI789012",
+                  "amount": {
+                    "value": "1.0",
+                    "unit": "EACHES"
+                  },
+                  "unitIdentifiers": {
+                    "SKU": ["ABC123", "XYZ789"],
+                    "ASIN": ["B01234567", "B07654321"],
+                    "UPC": ["012345678901", "987654321098"]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "FulfillmentCenter": {
+      "type": "object",
+      "description": "Details of the Amazon fulfillment center that the shipment is sent from.",
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "An identifier for the Amazon fulfillment center that the shipment is sent from.",
+          "example": "FC123"
+        },
+        "address": {
+          "$ref": "#/definitions/Address",
+          "description": "The fulfillment center address the shipment originated from."
+        }
+      },
+      "example": {
+        "id": "FC123",
+        "address": {
+          "name": "FC123",
+          "addressLine1": "940 W Bethel Road",
+          "city": "Coppell",
+          "stateOrRegion": "TX",
+          "postalCode": "75019-4424",
+          "countryCode": "US"
+        }
+      }
+    },
+    "Locker": {
+      "type": "object",
+      "properties": {
+        "number": {
+          "type": "string",
+          "description": "Indicates the locker number"
+        },
+        "accessCode": {
+          "type": "string",
+          "description": "Indicates the locker access code"
+        }
+      },
+      "description": "The locker details, which you can use to access the locker delivery box.",
+      "example": {
+        "number": "123",
+        "accessCode": "7890"
+      }
+    },
+    "DeliveryDocument": {
+      "type": "object",
+      "required": ["documentType"],
+      "properties": {
+        "documentType": {
+          "type": "string",
+          "description": "Indicates the type of the delivery document. It can have values like `SIGNATURE`, `DELIVERY_IMAGE`, etc."
+        },
+        "url": {
+          "type": "string",
+          "description": "A URL that is valid for one hour to download the document. In case of URL expiry, call the API again to get a new url. The URL will have a Content-Type header."
+        }
+      },
+      "description": "A delivery document for a package.",
+      "example": {
+        "documentType": "SIGNATURE",
+        "url": "someUrl"
+      }
+    },
+    "Shipment": {
+      "type": "object",
+      "required": ["amazonShipmentId", "fulfillmentCenter", "items", "status"],
+      "properties": {
+        "amazonShipmentId": {
+          "type": "string",
+          "description": "A shipment identifier assigned by Amazon."
+        },
+        "fulfillmentCenter": {
+          "$ref": "#/definitions/FulfillmentCenter"
+        },
+        "status": {
+          "$ref": "#/definitions/ShipmentStatus"
+        },
+        "shipTime": {
+          "description": "The meaning of the shippingDate value depends on the current status of the shipment. If the current value of shipmentstatus is:\n\n* Processing - shippingDate represents the estimated time that the shipment will leave the Amazon fulfillment center.\n\n* Shipped - shippingDate represents the date that the shipment left the Amazon fulfillment center.\nIf a shipment includes more than one package, shippingDate applies to all of the packages in the shipment. If the value of shipmentstatus is Cancelled, shippingDate is not returned. The value must be in ISO 8601 date time format.",
+          "$ref": "#/definitions/Timestamp"
+        },
+        "deliveryTime": {
+          "description": "The estimated delivery date and time of the shipment, in ISO 8601 date time format. Note that this value can change over time. If a shipment includes more than one package, estimatedDeliveryTime applies to all of the packages in the shipment. If the shipment has been cancelled, estimatedDeliveryTime is not returned.",
+          "$ref": "#/definitions/Timestamp"
+        },
+        "shippingNotes": {
+          "type": "array",
+          "description": "Provides additional insight into shipment timeline. Primarily used to communicate that actual delivery dates aren't available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ShipmentItem"
+          },
+          "description": "An array of fulfillment shipment item information."
+        },
+        "shipmentPackages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ShipmentPackage"
+          },
+          "description": "An array of fulfillment shipment package information."
+        }
+      },
+      "description": "Delivery and item information for a shipment in a fulfillment order.",
+      "example": {
+        "amazonShipmentId": "123456",
+        "fulfillmentCenter": {
+          "id": "ABC123"
+        },
+        "status": "PROCESSING",
+        "shipTime": "2025-04-21T12:34:56Z",
+        "deliveryTime": "2025-04-23T12:34:56Z",
+        "shippingNotes": ["Delivery date not available"],
+        "items": [
+          {
+            "productIdentifier": {
+              "amazonSku": "SKU123"
+            },
+            "lineItemId": "item1",
+            "amount": {
+              "value": "1"
+            }
+          }
+        ],
+        "shipmentPackages": [
+          {
+            "packageNumber": "1",
+            "status": "DELIVERED",
+            "carrierTracking": {
+              "carrierCode": "FEDEX",
+              "trackingNumber": "123456789",
+              "trackingUrl": "https://www.swiship.com/track?id=SampleTrackingNumber1"
+            },
+            "amazonTracking": {
+              "trackingNumber": "123456789",
+              "trackingUrl": "https://www.swiship.com/track?id=SampleTrackingNumber1"
+            }
+          }
+        ]
+      }
+    },
+    "ShipmentStatus": {
+      "type": "string",
+      "description": "The current status of the shipment. Possible values are PROCESSING, SHIPPED, CANCELLED.",
+      "x-docgen-enum-table-extension": [
+        {
+          "value": "PROCESSING",
+          "description": "The process of picking units from inventory has begun."
+        },
+        {
+          "value": "SHIPPED",
+          "description": "All packages in the shipment have left the fulfillment center."
+        },
+        {
+          "value": "CANCELLED",
+          "description": "The shipment was cancelled using the CancelOrder request."
+        }
+      ],
+      "example": "PROCESSING"
+    },
+    "ShipmentPackage": {
+      "type": "object",
+      "required": ["packageNumber", "status"],
+      "properties": {
+        "packageNumber": {
+          "type": "string",
+          "description": "Identifies a package in a shipment."
+        },
+        "deliveryTime": {
+          "description": "The estimated delivery date and time of the package, in ISO 8601 date time format.",
+          "$ref": "#/definitions/Timestamp"
+        },
+        "locker": {
+          "description": "The locker details, which you can use to access the locker delivery box.",
+          "$ref": "#/definitions/Locker"
+        },
+        "signatureUrl": {
+          "type": "string",
+          "description": "The url for displaying the signature provided on Delivery"
+        },
+        "deliveryPhotoUrl": {
+          "type": "string",
+          "description": "The url for displaying the photo taken on Delivery"
+        },
+        "dropOffLocation": {
+          "description": "The drop off location for a package.",
+          "$ref": "#/definitions/OrderDropOffLocation"
+        },
+        "status": {
+          "$ref": "#/definitions/ShipmentPackageStatus"
+        },
+        "carrierTracking": {
+          "$ref": "#/definitions/CarrierTracking"
+        },
+        "amazonTracking": {
+          "$ref": "#/definitions/AmazonTracking"
+        }
+      },
+      "description": "Package information for a shipment in a fulfillment order.",
+      "example": {
+        "packageNumber": "123",
+        "status": "DELIVERED",
+        "carrierTracking": {
+          "carrierCode": "AMZL",
+          "trackingNumber": "Tracking123",
+          "trackingUrl": "https://www.swiship.com/track?id=SampleTrackingNumber1"
+        },
+        "amazonTracking": {
+          "trackingNumber": "Tracking123",
+          "trackingUrl": "https://www.swiship.com/track?id=SampleTrackingNumber1"
+        },
+        "deliveryTime": "2025-04-21T12:34:56Z",
+        "locker": {
+          "number": "123",
+          "accessCode": "7890"
+        },
+        "signatureUrl": "https://doc-bucket.s3.amazonaws.com/AMZ123456789/signature.png?x-amz-expires=3600",
+        "deliveryPhotoUrl": "https://doc-bucket.s3.amazonaws.com/AMZ123456789/delivered.jpg?x-amz-expires=3600",
+        "dropOffLocation": {
+          "type": "FALLBACK_NEIGHBOR_DELIVERY",
+          "attributes": {
+            "neighborName": "Frank Doe",
+            "houseNumber": "142"
+          }
+        }
+      }
+    },
+    "UpdatePackageRequest": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ShipmentPackageStatus"
+        },
+        "deliveryTime": {
+          "description": "The estimated delivery date and time of the package, in ISO 8601 date time format.",
+          "$ref": "#/definitions/Timestamp"
+        },
+        "carrierTracking": {
+          "$ref": "#/definitions/CarrierTracking"
+        },
+        "amazonTracking": {
+          "$ref": "#/definitions/AmazonTracking"
+        }
+      },
+      "description": "Package information to update for a specific package in a fulfillment order.",
+      "example": {
+        "status": "DELIVERED",
+        "deliveryTime": "2025-04-21T12:34:56Z",
+        "carrierTracking": {
+          "trackingNumber": "1Z50V7420354708051",
+          "carrierCode": "UPS",
+          "trackingUrl": "https://www.swiship.com/track?id=SampleTrackingNumber1"
+        },
+        "amazonTracking": {
+          "trackingNumber": "1Z50V7420354708051",
+          "trackingUrl": "https://www.swiship.com/track?id=SampleTrackingNumber1"
+        }
+      }
+    },
+    "ShipmentPackageStatus": {
+      "type": "string",
+      "description": "The current status of a package. Possible values are PROCESSING, IN_TRANSIT, DELAYED, OUT_FOR_DELIVERY, DELIVERED, UNDELIVERABLE.",
+      "example": "DELIVERED"
+    },
+    "ShipmentItem": {
+      "type": "object",
+      "required": ["amount", "lineItemId", "productIdentifier"],
+      "properties": {
+        "productIdentifier": {
+          "$ref": "#/definitions/ProductIdentifier"
+        },
+        "lineItemId": {
+          "type": "string",
+          "description": "The fulfillment order item identifier that the merchant created and submitted with a call to the createOrder operation."
+        },
+        "amount": {
+          "$ref": "#/definitions/Amount"
+        },
+        "packageNumber": {
+          "type": "string",
+          "description": "An identifier for the package that contains the item quantity."
+        },
+        "unitIdentifiers": {
+          "description": "The manufacturer lot codes of the shipped items.",
+          "$ref": "#/definitions/UnitIdentifiers"
+        }
+      },
+      "description": "Item information for a shipment in a fulfillment order.",
+      "example": {
+        "productIdentifier": {
+          "amazonSku": "product123"
+        },
+        "lineItemId": "lineItem1",
+        "amount": {
+          "unit": "EACHES",
+          "value": "1.0"
+        },
+        "packageNumber": "1",
+        "unitIdentifiers": {
+          "SKU": ["ABC123", "XYZ789"],
+          "ASIN": ["B01234567", "B07654321"],
+          "UPC": ["012345678901", "987654321098"]
+        }
+      }
+    },
+    "UnitIdentifiers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "description": "The value of the unit identifiers."
+        }
+      },
+      "description": "A map of unit identifier types to lists of identifier values",
+      "example": {
+        "SKU": ["ABC123", "XYZ789"],
+        "ASIN": ["B01234567", "B07654321"],
+        "UPC": ["012345678901", "987654321098"]
+      }
+    },
+    "FulfillmentOrder": {
+      "type": "object",
+      "required": ["orderId", "destination", "lineItems", "receiveTime"],
+      "properties": {
+        "orderId": {
+          "type": "string",
+          "description": "The fulfillment order identifier submitted with the createOrder operation."
+        },
+        "receiveTime": {
+          "$ref": "#/definitions/Timestamp",
+          "description": "The date and time that the fulfillment order was received."
+        },
+        "status": {
+          "$ref": "#/definitions/OrderStatus",
+          "description": "The current status of the fulfillment order."
+        },
+        "statusUpdateTime": {
+          "$ref": "#/definitions/Timestamp",
+          "description": "The date and time that the status of the fulfillment order last changed. Must be in ISO 8601 format."
+        },
+        "deliveryServiceLevel": {
+          "$ref": "#/definitions/DeliveryServiceLevel",
+          "description": "The delivery speed to be used to fulfill the order. Possible values: STANDARD, EXPEDITED, PRIORITY, SCHEDULED."
+        },
+        "fulfillmentAction": {
+          "$ref": "#/definitions/OrderFulfillmentAction",
+          "description": "Specifies whether the fulfillment order should ship now or have an order hold put on it. Possible values: HOLD, SHIP."
+        },
+        "fulfillmentPolicy": {
+          "$ref": "#/definitions/OrderFulfillmentPolicy",
+          "description": "The policy for the fulfillment order. Possible values: FILL_OR_KILL, FILL_ALL and FILL_ALL_AVAILABLE"
+        },
+        "destination": {
+          "$ref": "#/definitions/OrderDestination",
+          "description": "The destination for the fulfillment."
+        },
+        "origin": {
+          "$ref": "#/definitions/OrderOrigin",
+          "description": "The origin for the fulfillment order."
+        },
+        "services": {
+          "$ref": "#/definitions/OrderServices",
+          "description": "Services selected for the order."
+        },
+        "lineItems": {
+          "type": "array",
+          "description": "A list of items to include in the fulfillment order, including quantity.",
+          "items": {
+            "$ref": "#/definitions/OrderLineItem"
+          }
+        },
+        "shipments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Shipment"
+          },
+          "description": "An array of fulfillment shipment information."
+        }
+      },
+      "description": "General information about a fulfillment order, including its status.",
+      "example": {
+        "deliveryServiceLevel": "STANDARD",
+        "orderId": "ABC123XYZ",
+        "receiveTime": "2025-04-21T10:30:00Z",
+        "status": "PROCESSING",
+        "fulfillmentAction": "HOLD",
+        "fulfillmentPolicy": "FILL_ALL_AVAILABLE",
+        "statusUpdateTime": "2025-04-21T11:45:00Z",
+        "origin": {
+          "countryCode": "US"
+        },
+        "destination": {
+          "deliveryAddress": {
+            "name": "Shopper Name",
+            "addressLine1": "1000 Winthrop Ave N",
+            "addressLine2": "Floor 19",
+            "addressLine3": "ATTN: Shopper",
+            "city": "Seattle",
+            "districtOrCounty": "None",
+            "countryCode": "US",
+            "phone": "123-456-7890",
+            "postalCode": "98103",
+            "stateOrRegion": "WA",
+            "email": "shopper@email.com"
+          },
+          "deliveryNotes": "Please beware of dogs.",
+          "dropOffLocation": {
+            "type": "FALLBACK_NEIGHBOR_DELIVERY",
+            "attributes": {
+              "neighborName": "neighborName",
+              "houseNumber": "houseNumber"
+            }
+          }
+        },
+        "services": {
+          "packaging": {
+            "blankBox": "REQUIRED",
+            "packingSlip": {
+              "templateName": "templateName",
+              "templateAttributes": {
+                "attributeName1": "attributeValue1",
+                "attributeName2": "attributeValue2"
+              }
+            }
+          },
+          "additionalServices": {
+            "serviceName": "REQUIRED"
+          }
+        },
+        "lineItems": [
+          {
+            "lineItemId": "someLineItemId",
+            "product": {
+              "productIdentifier": {
+                "amazonSku": "BOOK-123-HC"
+              },
+              "perUnitDeclaredValue": {
+                "currencyCode": "USD",
+                "amount": "14.99"
+              }
+            },
+            "amount": {
+              "unit": "EACHES",
+              "value": "1.0"
+            },
+            "cancelledAmount": {
+              "unit": "EACHES",
+              "value": "0"
+            },
+            "unfulfillableAmount": {
+              "unit": "EACHES",
+              "value": "0"
+            },
+            "perUnitDeclaredValue": {
+              "currencyCode": "USD",
+              "amount": "3.00"
+            },
+            "services": {
+              "packaging": {
+                "packingSlip": {
+                  "templateName": "templateName",
+                  "templateAttributes": {
+                    "attributeName1": "attributeValue1",
+                    "attributeName2": "attributeValue2"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "shipments": [
+          {
+            "amazonShipmentId": "SHIP901234",
+            "fulfillmentCenter": {
+              "id": "FC456"
+            },
+            "status": "SHIPPED",
+            "shipTime": "2025-04-21T15:00:00Z",
+            "deliveryTime": "2025-04-23T12:00:00Z",
+            "items": [
+              {
+                "productIdentifier": {
+                  "amazonSku": "SKU123"
+                },
+                "lineItemId": "LI789012",
+                "amount": {
+                  "value": "1.0",
+                  "unit": "EACHES"
+                },
+                "unitIdentifiers": {
+                  "SKU": ["ABC123", "XYZ789"],
+                  "ASIN": ["B01234567", "B07654321"],
+                  "UPC": ["012345678901", "987654321098"]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "ListOrdersResponse": {
+      "type": "object",
+      "required": ["fulfillmentOrders"],
+      "properties": {
+        "fulfillmentOrders": {
+          "type": "array",
+          "description": "A list of fulfillment orders.",
+          "items": {
+            "$ref": "#/definitions/FulfillmentOrder"
+          }
+        },
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        }
+      },
+      "description": "The response schema for the listOrders operation."
+    },
+    "Pagination": {
+      "type": "object",
+      "properties": {
+        "nextToken": {
+          "type": "string",
+          "description": "A token that can be used to fetch the next page of results."
+        }
+      },
+      "description": "Pagination information for the results."
+    },
+    "UpdateOrderStatusRequest": {
+      "type": "object",
+      "description": "The request body schema for the updateOrderStatus operation.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/OrderStatus",
+          "description": "The status of the fulfillment order to apply."
+        }
+      },
+      "required": ["status"],
+      "example": {
+        "status": "PROCESSING"
+      }
+    },
+    "AmazonTracking": {
+      "type": "object",
+      "description": "Amazon tracking information for a package.",
+      "properties": {
+        "trackingNumber": {
+          "type": "string",
+          "description": "The amazon tracking number that can be used to obtain tracking and delivery information."
+        },
+        "trackingUrl": {
+          "type": "string",
+          "description": "Represents the tracking url where amazon tracking information is shown."
+        }
+      },
+      "example": {
+        "trackingNumber": "1Z50V7420354708051",
+        "trackingUrl": "https://www.swiship.com/track?id=SampleTrackingNumber1"
+      }
+    },
+    "CarrierTracking": {
+      "type": "object",
+      "description": "Carrier tracking information for a package.",
+      "required": ["carrierCode"],
+      "properties": {
+        "trackingNumber": {
+          "type": "string",
+          "description": "The tracking number, if provided, can be used to obtain tracking and delivery information."
+        },
+        "carrierCode": {
+          "type": "string",
+          "description": "Identifies the carrier who will deliver the shipment to the recipient."
+        },
+        "trackingUrl": {
+          "type": "string",
+          "description": "Represents the tracking url where package tracking information is shown."
+        }
+      },
+      "example": {
+        "trackingNumber": "1Z50V7420354708051",
+        "carrierCode": "UPS",
+        "trackingUrl": "https://www.swiship.com/track?id=SampleTrackingNumber1"
+      }
+    },
+    "CreateFulfillmentServiceRequest": {
+      "type": "object",
+      "required": ["fulfillmentService"],
+      "description": "The request body schema for the createFulfillmentService operation.",
+      "properties": {
+        "fulfillmentService": {
+          "description": "Default configurations for fulfillment operations.",
+          "$ref": "#/definitions/CreateFulfillmentService"
+        }
+      },
+      "example": {
+        "fulfillmentService": {
+          "merchantAccountId": "amzn1.merchant.o.A3SR1GB2AWB5VA",
+          "displayName": "First Channel",
+          "description": "First description",
+          "defaultFulfillmentSettings": {
+            "services": {
+              "packaging": {
+                "blankBox": "REQUIRED",
+                "packingSlip": {
+                  "template": "Packing template"
+                }
+              },
+              "delivery": {
+                "deliverTogether": "REQUIRED",
+                "signatureOnDelivery": "REQUIRED"
+              },
+              "additionalServices": {
+                "serviceName": "REQUIRED"
+              }
+            }
+          }
+        }
+      }
+    },
+    "CreateFulfillmentService": {
+      "type": "object",
+      "required": ["merchantAccountId"],
+      "description": "The fulfillment service fields available on creation.",
+      "properties": {
+        "merchantAccountId": {
+          "description": "Your merchant account identifier to associate with this fulfillment service.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "The optional name to identify this fulfillment service.",
+          "type": "string"
+        },
+        "description": {
+          "description": "The optional description for this fulfillment service.",
+          "type": "string"
+        },
+        "defaultFulfillmentSettings": {
+          "description": "Default configurations for fulfillment operations.",
+          "$ref": "#/definitions/DefaultFulfillmentSettings"
+        }
+      },
+      "example": {
+        "merchantAccountId": "amzn1.merchant.o.A3SR1GB2AWB5VA",
+        "displayName": "First Channel",
+        "description": "First description",
+        "defaultFulfillmentSettings": {
+          "services": {
+            "packaging": {
+              "blankBox": "REQUIRED",
+              "packingSlip": {
+                "template": "Packing template"
+              }
+            },
+            "delivery": {
+              "deliverTogether": "REQUIRED",
+              "signatureOnDelivery": "REQUIRED"
+            },
+            "additionalServices": {
+              "serviceName": "REQUIRED"
+            }
+          }
+        }
+      }
+    },
+    "CreateFulfillmentServiceResponse": {
+      "type": "object",
+      "required": ["id", "status"],
+      "description": "The response body schema for the createFulfillmentService operation.",
+      "properties": {
+        "id": {
+          "description": "A unique identifier for the fulfillment service.",
+          "type": "string"
+        },
+        "status": {
+          "description": "The status of the fulfillment service. Possible values are 'ACTIVE' and 'INACTIVE'.",
+          "type": "string"
+        }
+      },
+      "example": {
+        "id": "FS01-o8vlfw8b1tiu1",
+        "status": "ACTIVE"
+      }
+    },
+    "GetFulfillmentServiceResponse": {
+      "type": "object",
+      "required": ["fulfillmentService"],
+      "description": "The response body schema for the getFulfillmentService operation.",
+      "properties": {
+        "fulfillmentService": {
+          "description": "The fulfillment service.",
+          "$ref": "#/definitions/FulfillmentService"
+        }
+      },
+      "example": {
+        "fulfillmentService": {
+          "id": "FS01-o8vlfw8b1tiu1",
+          "displayName": "First Channel",
+          "description": "First description",
+          "merchantAccountId": "amzn1.merchant.o.A3SR1GB2AWB5VA",
+          "status": "ACTIVE",
+          "defaultFulfillmentSettings": {
+            "services": {
+              "packaging": {
+                "blankBox": "REQUIRED",
+                "packingSlip": {
+                  "template": "Packing template"
+                }
+              },
+              "delivery": {
+                "deliverTogether": "REQUIRED",
+                "signatureOnDelivery": "REQUIRED"
+              },
+              "additionalServices": {
+                "serviceName": "REQUIRED"
+              }
+            }
+          }
+        }
+      }
+    },
+    "UpdateFulfillmentServiceRequest": {
+      "type": "object",
+      "description": "The request body schema for the updateFulfillmentService operation.",
+      "properties": {
+        "fulfillmentService": {
+          "description": "The updated fulfillment service.",
+          "$ref": "#/definitions/UpdateFulfillmentService"
+        }
+      },
+      "example": {
+        "fulfillmentService": {
+          "status": "INACTIVE",
+          "displayName": "Updated name",
+          "description": "Updated description",
+          "defaultFulfillmentSettings": {
+            "services": {
+              "packaging": {
+                "blankBox": "REQUIRED",
+                "packingSlip": {
+                  "template": "Packing template"
+                }
+              },
+              "delivery": {
+                "deliverTogether": "REQUIRED",
+                "signatureOnDelivery": "REQUIRED"
+              },
+              "additionalServices": {
+                "serviceName": "REQUIRED"
+              }
+            }
+          }
+        }
+      }
+    },
+    "UpdateFulfillmentService": {
+      "type": "object",
+      "description": "The updatable fields in a fulfillment service.",
+      "properties": {
+        "displayName": {
+          "description": "The new name given to this fulfillment service.",
+          "type": "string"
+        },
+        "description": {
+          "description": "The optional new description for this fulfillment service.",
+          "type": "string"
+        },
+        "status": {
+          "description": "The status of this fulfillment service. Possible values are 'ACTIVE' and 'INACTIVE'. An 'INACTIVE' fulfillment service can be used to read fulfillment order data, but cannot be used to create new fulfillments or request new delivery estimates. 'ACTIVE' fulfillment services can be used to create fulfillments, retrieve delivery estimates, and read fulfillment order data.",
+          "type": "string"
+        },
+        "defaultFulfillmentSettings": {
+          "description": "Default configurations for fulfillment operations.",
+          "$ref": "#/definitions/DefaultFulfillmentSettings"
+        }
+      },
+      "example": {
+        "status": "ACTIVE",
+        "displayName": "New Channel",
+        "description": "First description",
+        "defaultFulfillmentSettings": {
+          "services": {
+            "packaging": {
+              "blankBox": "REQUIRED",
+              "packingSlip": {
+                "template": "Packing template"
+              }
+            },
+            "delivery": {
+              "deliverTogether": "REQUIRED",
+              "signatureOnDelivery": "REQUIRED"
+            },
+            "additionalServices": {
+              "serviceName": "REQUIRED"
+            }
+          }
+        }
+      }
+    },
+    "ListFulfillmentServicesResponse": {
+      "type": "object",
+      "required": ["fulfillmentServices"],
+      "description": "The response body schema for the ListFulfillmentServices operation.",
+      "properties": {
+        "fulfillmentServices": {
+          "description": "The retrieved fulfillment services.",
+          "$ref": "#/definitions/FulfillmentServiceList"
+        },
+        "pagination": {
+          "description": "If available, the nextToken value required to return paginated results.",
+          "$ref": "#/definitions/Pagination"
+        }
+      },
+      "example": {
+        "fulfillmentServices": [
+          {
+            "id": "FS01-o8vlfw8b1tiu1",
+            "displayName": "First Channel",
+            "description": "First description",
+            "merchantAccountId": "amzn1.merchant.o.A3SR1GB2AWB5VA",
+            "status": "ACTIVE",
+            "defaultFulfillmentSettings": {
+              "services": {
+                "packaging": {
+                  "blankBox": "REQUIRED",
+                  "packingSlip": {
+                    "template": "Packing template"
+                  }
+                },
+                "delivery": {
+                  "deliverTogether": "REQUIRED",
+                  "signatureOnDelivery": "REQUIRED"
+                },
+                "additionalServices": {
+                  "serviceName": "REQUIRED"
+                }
+              }
+            }
+          },
+          {
+            "id": "0uykurg8",
+            "displayName": "Second Channel",
+            "merchantAccountId": "amzn1.merchant.o.A3SR1GB2AWB5VA",
+            "status": "ACTIVE",
+            "defaultFulfillmentSettings": {
+              "services": {
+                "packaging": {
+                  "blankBox": "NOT_REQUIRED",
+                  "packingSlip": {
+                    "template": "Packing template"
+                  }
+                },
+                "additionalServices": {
+                  "serviceName": "REQUIRED"
+                }
+              }
+            }
+          }
+        ],
+        "pagination": {
+          "nextToken": "asdbasdrweghtjrt"
+        }
+      }
+    },
+    "FulfillmentService": {
+      "type": "object",
+      "description": "A valid fulfillment service.",
+      "required": ["id", "merchantAccountId", "status"],
+      "properties": {
+        "id": {
+          "description": "A unique identifier for the fulfillment service.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "The name given to this fulfillment service.",
+          "type": "string"
+        },
+        "description": {
+          "description": "The optional description for this fulfillment service.",
+          "type": "string"
+        },
+        "merchantAccountId": {
+          "description": "Your merchant account identifier associated with this fulfillment service.",
+          "type": "string"
+        },
+        "status": {
+          "description": "The status of this fulfillment service. Possible values are 'ACTIVE' and 'INACTIVE'. An 'INACTIVE' fulfillment service can be used to read fulfillment order data, but cannot be used to create new fulfillments or request new delivery estimates. 'ACTIVE' fulfillment services can be used to create fulfillments, retrieve delivery estimates, and read fulfillment order data.",
+          "type": "string"
+        },
+        "defaultFulfillmentSettings": {
+          "description": "Default configurations for fulfillment operations.",
+          "$ref": "#/definitions/DefaultFulfillmentSettings"
+        }
+      },
+      "example": {
+        "status": "ACTIVE",
+        "id": "FS01-o8vlfw8b1tiu1",
+        "displayName": "First Channel",
+        "description": "First description",
+        "merchantAccountId": "amzn1.merchant.o.A3SR1GB2AWB5VA",
+        "defaultFulfillmentSettings": {
+          "services": {
+            "packaging": {
+              "blankBox": "REQUIRED",
+              "packingSlip": {
+                "template": "Packing template"
+              }
+            },
+            "delivery": {
+              "deliverTogether": "REQUIRED",
+              "signatureOnDelivery": "REQUIRED"
+            },
+            "additionalServices": {
+              "serviceName": "REQUIRED"
+            }
+          }
+        }
+      }
+    },
+    "FulfillmentServiceList": {
+      "type": "array",
+      "description": "An array of fulfillment services.",
+      "items": {
+        "$ref": "#/definitions/FulfillmentService"
+      }
+    },
+    "DefaultFulfillmentSettings": {
+      "type": "object",
+      "description": "Default configurations for fulfillments.",
+      "properties": {
+        "services": {
+          "description": "Fulfillment configurations.",
+          "$ref": "#/definitions/FulfillmentServiceServices"
+        }
+      }
+    },
+    "FulfillmentServiceServices": {
+      "type": "object",
+      "description": "The fulfillment configurations.",
+      "properties": {
+        "packaging": {
+          "description": "Packaging specific configurations.",
+          "$ref": "#/definitions/FulfillmentServicePackaging"
+        },
+        "delivery": {
+          "description": "Delivery specific configurations.",
+          "$ref": "#/definitions/FulfillmentServiceDelivery"
+        },
+        "additionalServices": {
+          "description": "Additional configurations.",
+          "$ref": "#/definitions/FulfillmentServiceAdditional"
+        }
+      }
+    },
+    "FulfillmentServicePackaging": {
+      "type": "object",
+      "description": "Packaging configuration options.",
+      "properties": {
+        "blankBox": {
+          "description": "Whether orders should default to using blank boxes for fulfillment. Valid values are REQUIRED and NOT_REQUIRED",
+          "type": "string"
+        },
+        "packingSlip": {
+          "description": "Packing slip configuration to use for fulfillment orders.",
+          "$ref": "#/definitions/FulfillmentServicePackingSlip"
+        }
+      }
+    },
+    "FulfillmentServiceDelivery": {
+      "type": "object",
+      "description": "Delivery configuration options.",
+      "properties": {
+        "deliverTogether": {
+          "description": "Whether orders should default to delivering together. Valid values are REQUIRED and NOT_REQUIRED",
+          "type": "string"
+        },
+        "signatureOnDelivery": {
+          "description": "Whether orders should default to requiring signatures on delivery. Valid values are ADULT_REQUIRED, REQUIRED, and NOT_REQUIRED",
+          "type": "string"
+        }
+      }
+    },
+    "FulfillmentServiceAdditional": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Request additional services",
+      "example": {
+        "serviceName": "REQUIRED"
+      }
+    },
+    "FulfillmentServicePackingSlip": {
+      "type": "object",
+      "description": "Packing slip information",
+      "properties": {
+        "template": {
+          "description": "A custom packing slip template.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/resources/outbound-fulfillment-migration-data.json
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/resources/outbound-fulfillment-migration-data.json
@@ -1,0 +1,393 @@
+{
+  "name": "Outbound Fulfillment Migration Data",
+  "description": "Migration mapping data for Fulfillment Outbound API v2020-07-01 to v2025-09-24",
+  "version": "1.0.0",
+  "deprecated": [
+    "getFeatures",
+    "getFeatureSKU",
+    "getFeatureInventory",
+    "createFulfillmentReturn",
+    "listReturnReasonCodes",
+    "getPackageTrackingDetails",
+    "includeDeliveryWindows",
+    "earliestShipDate",
+    "latestShipDate"
+  ],
+  "notSupported": [
+    "getFeatures - Check documentation for supported feature constraints and services",
+    "getFeatureSKU - Check documentation for supported feature constraints and services",
+    "getFeatureInventory - Use getOrderPreview to check if products are fulfillable",
+    "createFulfillmentReturn - Deprecated in v2025-09-24",
+    "listReturnReasonCodes - Deprecated in v2025-09-24",
+    "getPackageTrackingDetails - Moved to Amazon Tracking API"
+  ],
+  "attributeMappings": {
+    "sellerFulfillmentOrderId": "orderId",
+    "shippingSpeedCategory": "deliveryServiceLevel",
+    "destinationAddress": "destination.deliveryAddress",
+    "marketplaceId": "origin.countryCode",
+    "items": "lineItems",
+    "featureConstraints": "services",
+    "deliveryPreferences": "destination.deliveryNotes / destination.dropOffLocation",
+    "codSettings": "services.delivery.paymentOnDelivery",
+    "sellerSKU": "product.productIdentifier.amazonSku",
+    "sellerFulfillmentOrderItemId": "lineItemId",
+    "quantity": "amount.value",
+    "fulfillmentOrderStatus": "status",
+    "statusUpdatedDate": "statusUpdateTime",
+    "receivedDate": "receiveTime",
+    "fulfillmentShipments": "shipments",
+    "fulfillmentShipmentPackage": "shipmentPackages",
+    "serialNumber": "unitIdentifiers",
+    "fulfillmentCenterId": "fulfillmentCenter.id",
+    "fulfillmentShipmentStatus": "status",
+    "shippingDate": "shipTime",
+    "estimatedArrivalDate": "deliveryTime",
+    "fulfillmentPreviewShipments": "plannedShipments[].offers",
+    "earliestArrivalDate": "deliveryInterval.startTime",
+    "latestArrivalDate": "deliveryInterval.endTime",
+    "fulfillmentPreviews": "plannedShipments",
+    "shippingSpeedCategories": "deliveryServiceLevels",
+    "address": "destination.deliveryAddress",
+    "queryStartDate": "updatedAfter",
+    "nextToken": "pageToken",
+    "expiresAt": "expiryTime",
+    "dateRange.earliest": "deliveryInterval.startTime",
+    "dateRange.latest": "deliveryInterval.endTime",
+    "policy.message": "policy.messaging"
+  },
+  "newFeatures": [
+    "Authorization: Interoperable use of merchant and partner account (multi-tenant) credentials",
+    "Channel-based feature configuration: Fulfillment services with distinct channels per merchant",
+    "x-amzn-fulfillment-service-id header for multi-site API scoping",
+    "New tenancy operations: Create, List, Retrieve, Update fulfillment services",
+    "FULFILLMENT_ORDER_STATUS notification v2025-09-24 with granular package-level updates (Delivered, In Transit, Delayed)",
+    "Webhook subscription support for notifications (in addition to SQS)",
+    "Subscription by Query (SBQ) with CEL filter expressions for event filtering",
+    "New event types: ORDER_STATUS_CHANGED, SHIPMENT_STATUS_CHANGED, SHIPMENT_PACKAGE_STATUS_CHANGED",
+    "updatePackage operation (PUT /orders/{orderId}/packages/{packageNumber}) for package status and tracking updates",
+    "deliveryOffers operation (POST /offers) for delivery date promises",
+    "Shipment query parameter (shipments=EXCLUDE/INCLUDE) on getOrder and listOrders",
+    "Sandbox status simulation with IN_TRANSIT, DELAYED, DELIVERED milestones",
+    "All enum values standardized to SCREAMING_SNAKE_CASE"
+  ],
+  "apiMappings": {
+    "createFulfillmentOrder": {
+      "v1": "createOrder",
+      "status": "✅ Available",
+      "notes": "POST /fulfillmentOrders → POST /orders. Request body restructured with new field names."
+    },
+    "getFulfillmentOrder": {
+      "v1": "getOrder",
+      "status": "✅ Available",
+      "notes": "GET /fulfillmentOrders/{sellerFulfillmentOrderId} → GET /orders/{orderId}. Supports shipments=EXCLUDE/INCLUDE query param."
+    },
+    "updateFulfillmentOrder": {
+      "v1": "updateOrder",
+      "status": "✅ Available",
+      "notes": "PUT /fulfillmentOrders/{sellerFulfillmentOrderId} → PUT /orders/{orderId}. Only fulfillmentAction needed in v2025-09-24."
+    },
+    "cancelFulfillmentOrder": {
+      "v1": "cancelOrder",
+      "status": "✅ Available",
+      "notes": "PUT /fulfillmentOrders/{sellerFulfillmentOrderId}/cancel → PUT /orders/{orderId}/cancel"
+    },
+    "listAllFulfillmentOrders": {
+      "v1": "listOrders",
+      "status": "✅ Available",
+      "notes": "GET /fulfillmentOrders → GET /orders. queryStartDate → updatedAfter, nextToken → pageToken."
+    },
+    "getFulfillmentPreview": {
+      "v1": "getOrderPreview",
+      "status": "✅ Available",
+      "notes": "POST /fulfillmentOrders/preview → POST /previews. Response uses plannedShipments with offers array inside each shipment."
+    },
+    "submitFulfillmentOrderStatusUpdate": {
+      "v1": "updateOrderStatus",
+      "status": "✅ Available",
+      "notes": "PUT /fulfillmentOrders/{id}/status → PUT /orders/{orderId}/status. Sandbox-only. Supports IN_TRANSIT, DELAYED, DELIVERED."
+    },
+    "deliveryOffers": {
+      "v1": "getOffers",
+      "status": "✅ Available",
+      "notes": "POST /deliveryOffers → POST /offers. Response: expiresAt → expiryTime, dateRange → deliveryInterval."
+    },
+    "getPackageTrackingDetails": {
+      "v1": "Moved to Amazon Tracking API",
+      "status": "❌ Not Available",
+      "notes": "Moved to a separate Amazon Tracking API. Continue using v2020-07-01 until Tracking API is GA. For package status updates, use updatePackage (PUT /orders/{orderId}/packages/{packageNumber})."
+    },
+    "getFeatures": {
+      "v1": "Deprecated",
+      "status": "❌ Not Available",
+      "notes": "Deprecated. Check documentation for supported feature constraints and services."
+    },
+    "getFeatureSKU": {
+      "v1": "Deprecated",
+      "status": "❌ Not Available",
+      "notes": "Deprecated. Check documentation for supported feature constraints and services."
+    },
+    "getFeatureInventory": {
+      "v1": "Deprecated",
+      "status": "❌ Not Available",
+      "notes": "Deprecated. Use getOrderPreview to check if products are fulfillable before placing an order."
+    },
+    "createFulfillmentReturn": {
+      "v1": "Deprecated",
+      "status": "❌ Not Available",
+      "notes": "Deprecated in v2025-09-24."
+    },
+    "listReturnReasonCodes": {
+      "v1": "Deprecated",
+      "status": "❌ Not Available",
+      "notes": "Deprecated in v2025-09-24."
+    }
+  },
+  "deliveryServiceLevelMappings": {
+    "Standard": "STANDARD",
+    "Expedited": "EXPEDITED",
+    "Priority": "PRIORITY",
+    "ScheduledDelivery": "SCHEDULED"
+  },
+  "fulfillmentActionMappings": {
+    "Ship": "SHIP",
+    "Hold": "HOLD"
+  },
+  "fulfillmentPolicyMappings": {
+    "FillOrKill": "FILL_OR_KILL",
+    "FillAll": "FILL_ALL",
+    "FillAllAvailable": "FILL_ALL_AVAILABLE"
+  },
+  "statusMappings": {
+    "fulfillmentOrderStatus": {
+      "New": "PROCESSING",
+      "Received": "PROCESSING",
+      "Planning": "PROCESSING",
+      "Processing": "PROCESSING",
+      "Complete": "COMPLETE",
+      "CompletePartialled": "COMPLETE_PARTIAL",
+      "Unfulfillable": "UNFULFILLABLE",
+      "Invalid": "INVALID"
+    },
+    "shipmentStatus": {
+      "PENDING": "PROCESSING",
+      "SHIPPED": "SHIPPED",
+      "CANCELLED": "CANCELLED"
+    },
+    "packageStatus": {
+      "PROCESSING": "PROCESSING",
+      "IN_TRANSIT": "IN_TRANSIT",
+      "DELAYED": "DELAYED",
+      "OUT_FOR_DELIVERY": "OUT_FOR_DELIVERY",
+      "DELIVERED": "DELIVERED",
+      "UNDELIVERABLE": "UNDELIVERABLE"
+    }
+  },
+  "queryParameterMappings": {
+    "queryStartDate": "updatedAfter (ISO 8601 format)",
+    "nextToken": "pageToken (Breaking: renamed pagination parameter)",
+    "ShippingSpeedCategories": "deliveryServiceLevels (Breaking: renamed and uppercase values)"
+  },
+  "requestBodyChanges": {
+    "createFulfillmentOrder": {
+      "removed": ["includeDeliveryWindows"],
+      "renamed": {
+        "sellerFulfillmentOrderId": "orderId",
+        "shippingSpeedCategory": "deliveryServiceLevel",
+        "destinationAddress": "destination.deliveryAddress",
+        "marketplaceId": "origin.countryCode",
+        "items": "lineItems",
+        "featureConstraints": "services",
+        "items[].sellerSKU": "lineItems[].product.productIdentifier.amazonSku",
+        "items[].sellerFulfillmentOrderItemId": "lineItems[].lineItemId",
+        "items[].quantity": "lineItems[].amount.value"
+      },
+      "added": [
+        "origin.countryCode",
+        "lineItems[].amount.unitOfMeasure",
+        "services.packaging",
+        "services.additionalServices"
+      ],
+      "enumChanges": {
+        "fulfillmentAction": "Ship → SHIP, Hold → HOLD",
+        "fulfillmentPolicy": "FillOrKill → FILL_OR_KILL, FillAll → FILL_ALL, FillAllAvailable → FILL_ALL_AVAILABLE",
+        "shippingSpeedCategory/deliveryServiceLevel": "Standard → STANDARD, Expedited → EXPEDITED, Priority → PRIORITY"
+      }
+    },
+    "getFulfillmentPreview": {
+      "removed": [
+        "includeDeliveryWindows",
+        "earliestShipDate",
+        "latestShipDate"
+      ],
+      "renamed": {
+        "address": "destination.deliveryAddress",
+        "items": "lineItems",
+        "shippingSpeedCategories": "deliveryServiceLevels",
+        "marketplaceId": "origin.countryCode",
+        "featureConstraints": "services",
+        "items[].sellerSku": "lineItems[].product.productIdentifier.amazonSku",
+        "items[].sellerFulfillmentOrderItemId": "lineItems[].lineItemId (removed in preview)",
+        "items[].quantity": "lineItems[].amount.value"
+      },
+      "added": [
+        "origin.countryCode",
+        "lineItems[].amount.unitOfMeasure",
+        "services.packaging"
+      ],
+      "enumChanges": {
+        "shippingSpeedCategories": "Standard → STANDARD, Expedited → EXPEDITED, Priority → PRIORITY"
+      }
+    },
+    "updateFulfillmentOrder": {
+      "removed": ["Full order object no longer needed"],
+      "renamed": {
+        "fulfillmentAction": "fulfillmentAction (same name, new enum values)"
+      },
+      "added": [],
+      "enumChanges": {
+        "fulfillmentAction": "Ship → SHIP, Hold → HOLD"
+      }
+    },
+    "deliveryOffers": {
+      "removed": [],
+      "renamed": {
+        "product.productIdentifier.merchantSku": "product.productIdentifier.amazonSku",
+        "product.amount": "amount (moved to top level)",
+        "terms.origin": "origin (moved to top level)",
+        "terms.destination": "destination (moved to top level)"
+      },
+      "added": [],
+      "enumChanges": {
+        "unitOfMeasure": "Eaches → EACHES"
+      }
+    }
+  },
+  "responseChanges": {
+    "getFulfillmentOrder": {
+      "renamed": {
+        "payload.fulfillmentOrder": "fulfillmentOrder (no payload wrapper)",
+        "payload.fulfillmentOrderItems": "fulfillmentOrder.lineItems (nested inside order)",
+        "payload.fulfillmentShipments": "fulfillmentOrder.shipments (nested inside order)",
+        "fulfillmentOrderStatus": "status",
+        "statusUpdatedDate": "statusUpdateTime",
+        "receivedDate": "receiveTime",
+        "fulfillmentShipmentPackage": "shipmentPackages",
+        "fulfillmentCenterId": "fulfillmentCenter.id",
+        "shippingDate": "shipTime",
+        "estimatedArrivalDate": "deliveryTime",
+        "serialNumber": "unitIdentifiers"
+      },
+      "structureChanges": [
+        "No payload wrapper - response is direct object",
+        "Order items nested inside fulfillmentOrder as lineItems",
+        "Shipments nested inside fulfillmentOrder as shipments",
+        "Package tracking uses carrierTracking object with carrierCode and trackingNumber"
+      ]
+    },
+    "getFulfillmentPreview": {
+      "renamed": {
+        "payload.fulfillmentPreviews": "plannedShipments (no payload wrapper)",
+        "fulfillmentPreviewShipments": "plannedShipments[].offers",
+        "earliestArrivalDate": "deliveryInterval.startTime",
+        "latestArrivalDate": "deliveryInterval.endTime",
+        "shippingSpeedCategory": "deliveryServiceLevel",
+        "estimatedFees": "estimatedPrice.rollupPrices"
+      },
+      "structureChanges": [
+        "No payload wrapper - response is direct object",
+        "Delivery windows replaced by deliveryOffers with deliveryInterval",
+        "Fees restructured into estimatedPrice with rollupPrices and totalPrice",
+        "earliestShipDate and latestShipDate deprecated"
+      ]
+    },
+    "listAllFulfillmentOrders": {
+      "renamed": {
+        "payload.fulfillmentOrders": "fulfillmentOrders (no payload wrapper)",
+        "payload.nextToken": "pagination.pageToken"
+      },
+      "structureChanges": [
+        "No payload wrapper - response is direct object",
+        "Pagination moved to pagination.pageToken"
+      ]
+    },
+    "deliveryOffers": {
+      "renamed": {
+        "payload.deliveryOffers": "offers (no payload wrapper)",
+        "expiresAt": "expiryTime",
+        "dateRange.earliest": "deliveryInterval.startTime",
+        "dateRange.latest": "deliveryInterval.endTime",
+        "policy.message": "policy.messaging"
+      },
+      "structureChanges": ["No payload wrapper - response is direct object"]
+    }
+  },
+  "basePath": {
+    "old": "/fba/outbound/2020-07-01",
+    "new": "/fulfillment/outbound/2025-09-24"
+  },
+  "tenancyOperations": {
+    "description": "New operations for managing fulfillment services (multi-tenant support)",
+    "operations": {
+      "createFulfillmentService": {
+        "endpoint": "POST /fulfillment/outbound/2025-09-24/services",
+        "description": "Create a fulfillment service with default settings"
+      },
+      "listFulfillmentServices": {
+        "endpoint": "GET /fulfillment/outbound/2025-09-24/services",
+        "description": "List all fulfillment services for your account"
+      },
+      "getFulfillmentService": {
+        "endpoint": "GET /fulfillment/outbound/2025-09-24/services/{fulfillmentServiceId}",
+        "description": "Get metadata for a specific fulfillment service"
+      },
+      "updateFulfillmentService": {
+        "endpoint": "PUT /fulfillment/outbound/2025-09-24/services/{fulfillmentServiceId}",
+        "description": "Update fulfillment service metadata and default settings"
+      }
+    }
+  },
+  "notifications": {
+    "description": "Enhanced FULFILLMENT_ORDER_STATUS notification with granular package-level updates",
+    "eventTypes": {
+      "ORDER_STATUS_CHANGED": {
+        "statuses": [
+          "PROCESSING",
+          "COMPLETE",
+          "COMPLETE_PARTIAL",
+          "UNFULFILLABLE",
+          "CANCELLED"
+        ],
+        "description": "Tracks overall order state changes"
+      },
+      "SHIPMENT_STATUS_CHANGED": {
+        "statuses": ["PROCESSING", "SHIPPED", "CANCELLED"],
+        "description": "Tracks shipment-level status"
+      },
+      "SHIPMENT_PACKAGE_STATUS_CHANGED": {
+        "statuses": [
+          "IN_TRANSIT",
+          "DELAYED",
+          "DELIVERED",
+          "UNDELIVERABLE",
+          "RETURNED"
+        ],
+        "description": "Tracks individual package delivery status"
+      }
+    },
+    "webhookSupport": true,
+    "sbqFilterSupport": true,
+    "payloadVersion": "2025-09-24"
+  },
+  "migrationBenefits": [
+    "Simplified API schema: Cleaner URIs, consistent camelCase naming, SCREAMING_SNAKE_CASE enums",
+    "Multi-tenant support: Partner account credentials and channel-based fulfillment services",
+    "Granular notifications: Package-level delivery tracking (IN_TRANSIT, DELAYED, DELIVERED) via webhooks",
+    "Reduced API calls: Consolidated response structure eliminates need for multiple calls",
+    "Flexible event filtering: CEL-based subscription filters for precise event targeting",
+    "Simplified updates: updateOrder only requires fulfillmentAction field",
+    "Better delivery promises: deliveryOffers/getOffers with expiry times and delivery intervals",
+    "Enhanced sandbox: Simulate delivery milestones (IN_TRANSIT, DELAYED, DELIVERED)",
+    "No payload wrapper: Direct response objects without nested payload structure"
+  ]
+}

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/migration-assistant-tools/migration-tools.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/migration-assistant-tools/migration-tools.ts
@@ -256,6 +256,11 @@ export class SPAPIMigrationAssistantTool {
     };
   }
 
+  private static readonly OUTBOUND_DISCLAIMER =
+    "⚠️ DISCLAIMER: The Fulfillment Outbound API v2025-09-24 schema has NOT been " +
+    "officially released yet and is subject to change. Migration guidance provided " +
+    "here is based on a pre-release specification and may not reflect the final API.\n\n";
+
   private async handleOutboundFulfillmentMigration(
     sourceCode: string | undefined,
     sourceFiles: SourceFileInput[] | undefined,
@@ -274,7 +279,9 @@ export class SPAPIMigrationAssistantTool {
         content: [
           {
             type: "text",
-            text: formatOutboundGeneralGuidance(migrationData),
+            text:
+              SPAPIMigrationAssistantTool.OUTBOUND_DISCLAIMER +
+              formatOutboundGeneralGuidance(migrationData),
           },
         ],
       };
@@ -321,14 +328,23 @@ export class SPAPIMigrationAssistantTool {
           content: [
             {
               type: "text",
-              text: "No Fulfillment Outbound API v2020-07-01 usage detected in the provided files. No migration needed.",
+              text:
+                SPAPIMigrationAssistantTool.OUTBOUND_DISCLAIMER +
+                "No Fulfillment Outbound API v2020-07-01 usage detected in the provided files. No migration needed.",
             },
           ],
         };
       }
 
       return {
-        content: [{ type: "text", text: sections.join("\n\n---\n\n") }],
+        content: [
+          {
+            type: "text",
+            text:
+              SPAPIMigrationAssistantTool.OUTBOUND_DISCLAIMER +
+              sections.join("\n\n---\n\n"),
+          },
+        ],
       };
     }
 
@@ -340,7 +356,9 @@ export class SPAPIMigrationAssistantTool {
         content: [
           {
             type: "text",
-            text: formatOutboundAnalysisReport(analysis, migrationData),
+            text:
+              SPAPIMigrationAssistantTool.OUTBOUND_DISCLAIMER +
+              formatOutboundAnalysisReport(analysis, migrationData),
           },
         ],
       };
@@ -356,11 +374,13 @@ export class SPAPIMigrationAssistantTool {
       content: [
         {
           type: "text",
-          text: formatOutboundMigrationReport(
-            analysis,
-            refactoredCode,
-            migrationData,
-          ),
+          text:
+            SPAPIMigrationAssistantTool.OUTBOUND_DISCLAIMER +
+            formatOutboundMigrationReport(
+              analysis,
+              refactoredCode,
+              migrationData,
+            ),
         },
       ],
     };

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/migration-assistant-tools/migration-tools.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/migration-assistant-tools/migration-tools.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { dirname, join } from "path";
 import { getOrdersApiMigrationData } from "./orders-api-migration/migration-data.js";
 import { analyzeOrdersApiCode } from "./orders-api-migration/code-analyzer.js";
 import { generateRefactoredOrdersApiCode } from "./orders-api-migration/code-generator.js";
@@ -52,12 +52,7 @@ function resolveResourcePath(resourcesBase: string, fileName: string): string {
   // directory as the resources root. This keeps existing callers working that
   // passed the orders-api JSON path directly.
   if (resourcesBase.endsWith(".json")) {
-    const lastSep = Math.max(
-      resourcesBase.lastIndexOf("/"),
-      resourcesBase.lastIndexOf("\\"),
-    );
-    const dir = lastSep >= 0 ? resourcesBase.slice(0, lastSep) : ".";
-    return join(dir, fileName);
+    return join(dirname(resourcesBase), fileName);
   }
   return join(resourcesBase, fileName);
 }

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/migration-assistant-tools/migration-tools.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/migration-assistant-tools/migration-tools.ts
@@ -1,3 +1,4 @@
+import { join } from "path";
 import { getOrdersApiMigrationData } from "./orders-api-migration/migration-data.js";
 import { analyzeOrdersApiCode } from "./orders-api-migration/code-analyzer.js";
 import { generateRefactoredOrdersApiCode } from "./orders-api-migration/code-generator.js";
@@ -6,6 +7,14 @@ import {
   formatMigrationReport,
 } from "./orders-api-migration/report-formatter.js";
 import { formatGeneralGuidance } from "./orders-api-migration/guidance-formatter.js";
+import { getOutboundFulfillmentMigrationData } from "./outbound-fulfillment-migration/migration-data.js";
+import { analyzeOutboundFulfillmentCode } from "./outbound-fulfillment-migration/code-analyzer.js";
+import { generateRefactoredOutboundCode } from "./outbound-fulfillment-migration/code-generator.js";
+import {
+  formatOutboundAnalysisReport,
+  formatOutboundMigrationReport,
+} from "./outbound-fulfillment-migration/report-formatter.js";
+import { formatOutboundGeneralGuidance } from "./outbound-fulfillment-migration/guidance-formatter.js";
 
 export interface SourceFileInput {
   fileName: string;
@@ -31,11 +40,46 @@ export interface ToolResponse {
   [key: string]: unknown;
 }
 
-export class SPAPIMigrationAssistantTool {
-  private resourcePath: string;
+/**
+ * Resolves the resource path for a given migration data file.
+ *
+ * The constructor accepts either:
+ *   - a directory containing migration data JSON files (preferred), or
+ *   - a direct path to the orders-api-migration-data.json file (backwards-compatible).
+ */
+function resolveResourcePath(resourcesBase: string, fileName: string): string {
+  // If the caller passed a path that ends with a .json file, treat the parent
+  // directory as the resources root. This keeps existing callers working that
+  // passed the orders-api JSON path directly.
+  if (resourcesBase.endsWith(".json")) {
+    const lastSep = Math.max(
+      resourcesBase.lastIndexOf("/"),
+      resourcesBase.lastIndexOf("\\"),
+    );
+    const dir = lastSep >= 0 ? resourcesBase.slice(0, lastSep) : ".";
+    return join(dir, fileName);
+  }
+  return join(resourcesBase, fileName);
+}
 
-  constructor(resourcePath: string) {
-    this.resourcePath = resourcePath;
+export class SPAPIMigrationAssistantTool {
+  private ordersApiResourcePath: string;
+  private outboundFulfillmentResourcePath: string;
+
+  /**
+   * @param resourcesBase Either a directory containing migration data JSON
+   * files, or a direct path to orders-api-migration-data.json (for backwards
+   * compatibility with earlier callers).
+   */
+  constructor(resourcesBase: string) {
+    this.ordersApiResourcePath = resolveResourcePath(
+      resourcesBase,
+      "orders-api-migration-data.json",
+    );
+    this.outboundFulfillmentResourcePath = resolveResourcePath(
+      resourcesBase,
+      "outbound-fulfillment-migration-data.json",
+    );
   }
 
   async migrationAssistant(
@@ -57,6 +101,10 @@ export class SPAPIMigrationAssistantTool {
       "orders-v0->orders-2026-01-01": {
         source: "orders-v0",
         target: "orders-2026-01-01",
+      },
+      "fulfillment-outbound-v2020-07-01->fulfillment-outbound-2025-09-24": {
+        source: "fulfillment-outbound-v2020-07-01",
+        target: "fulfillment-outbound-2025-09-24",
       },
     };
 
@@ -93,6 +141,18 @@ export class SPAPIMigrationAssistantTool {
       );
     }
 
+    if (
+      source_version === "fulfillment-outbound-v2020-07-01" &&
+      target_version === "fulfillment-outbound-2025-09-24"
+    ) {
+      return this.handleOutboundFulfillmentMigration(
+        source_code,
+        source_files,
+        target_version,
+        analysis_only,
+      );
+    }
+
     return {
       content: [
         {
@@ -110,7 +170,7 @@ export class SPAPIMigrationAssistantTool {
     targetVersion: string,
     analysisOnly: boolean,
   ): Promise<ToolResponse> {
-    const migrationData = getOrdersApiMigrationData(this.resourcePath);
+    const migrationData = getOrdersApiMigrationData(this.ordersApiResourcePath);
 
     // Prefer source_files over source_code
     const hasSourceFiles = sourceFiles && sourceFiles.length > 0;
@@ -196,6 +256,116 @@ export class SPAPIMigrationAssistantTool {
         {
           type: "text",
           text: formatMigrationReport(analysis, refactoredCode, migrationData),
+        },
+      ],
+    };
+  }
+
+  private async handleOutboundFulfillmentMigration(
+    sourceCode: string | undefined,
+    sourceFiles: SourceFileInput[] | undefined,
+    targetVersion: string,
+    analysisOnly: boolean,
+  ): Promise<ToolResponse> {
+    const migrationData = getOutboundFulfillmentMigrationData(
+      this.outboundFulfillmentResourcePath,
+    );
+
+    const hasSourceFiles = sourceFiles && sourceFiles.length > 0;
+    const hasSourceCode = sourceCode && sourceCode.trim();
+
+    if (!hasSourceFiles && !hasSourceCode) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: formatOutboundGeneralGuidance(migrationData),
+          },
+        ],
+      };
+    }
+
+    // If source_files provided, process each file independently
+    if (hasSourceFiles) {
+      const sections: string[] = [];
+
+      for (const file of sourceFiles!) {
+        const code = file.code?.trim();
+        if (!code) continue;
+
+        const analysis = analyzeOutboundFulfillmentCode(code, migrationData);
+
+        // Skip files with no migration-relevant findings
+        if (
+          analysis.apiCalls.length === 0 &&
+          analysis.usedAttributes.length === 0 &&
+          analysis.breakingChanges.length === 0
+        ) {
+          continue;
+        }
+
+        if (analysisOnly) {
+          sections.push(
+            `# 📄 ${file.fileName}\n\n${formatOutboundAnalysisReport(analysis, migrationData)}`,
+          );
+        } else {
+          const refactoredCode = generateRefactoredOutboundCode(
+            code,
+            analysis,
+            targetVersion,
+            migrationData,
+          );
+          sections.push(
+            `# 📄 ${file.fileName}\n\n${formatOutboundMigrationReport(analysis, refactoredCode, migrationData)}`,
+          );
+        }
+      }
+
+      if (sections.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "No Fulfillment Outbound API v2020-07-01 usage detected in the provided files. No migration needed.",
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [{ type: "text", text: sections.join("\n\n---\n\n") }],
+      };
+    }
+
+    // Single source_code path
+    const analysis = analyzeOutboundFulfillmentCode(sourceCode!, migrationData);
+
+    if (analysisOnly) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: formatOutboundAnalysisReport(analysis, migrationData),
+          },
+        ],
+      };
+    }
+
+    const refactoredCode = generateRefactoredOutboundCode(
+      sourceCode!,
+      analysis,
+      targetVersion,
+      migrationData,
+    );
+    return {
+      content: [
+        {
+          type: "text",
+          text: formatOutboundMigrationReport(
+            analysis,
+            refactoredCode,
+            migrationData,
+          ),
         },
       ],
     };

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/migration-assistant-tools/outbound-fulfillment-migration/code-analyzer.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/migration-assistant-tools/outbound-fulfillment-migration/code-analyzer.ts
@@ -1,0 +1,254 @@
+import { OutboundMigrationData } from "./migration-data.js";
+
+/**
+ * Convert a camelCase name to snake_case (Python convention).
+ */
+function toSnakeCase(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+}
+
+/**
+ * Convert a camelCase name to PascalCase (C# convention).
+ */
+function toPascalCase(name: string): string {
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+/**
+ * Build a regex that matches a method name in camelCase, snake_case, and PascalCase.
+ */
+function buildMultiCaseRegex(camelCaseName: string): RegExp {
+  const snake = toSnakeCase(camelCaseName);
+  const pascal = toPascalCase(camelCaseName);
+  const variants = [...new Set([camelCaseName, snake, pascal])];
+  return new RegExp(`\\b(?:${variants.join("|")})\\b`, "g");
+}
+
+export interface OutboundCodeAnalysis {
+  deprecatedEndpoints: Array<{ endpoint: string; replacement: string }>;
+  breakingChanges: Array<{ change: string; explanation: string }>;
+  usedAttributes: Array<{ v0: string; v1: string; notes: string }>;
+  apiCalls: string[];
+  deliveryServiceLevelsUsed: Array<{ v0: string; v1: string }>;
+  fulfillmentActionsUsed: Array<{ v0: string; v1: string }>;
+  fulfillmentPoliciesUsed: Array<{ v0: string; v1: string }>;
+  statusMappingsUsed: Array<{ v0: string; v1: string }>;
+  queryParamsUsed: Array<{ v0: string; v1: string }>;
+  requestBodyChangesDetected: Array<{
+    api: string;
+    field: string;
+    change: string;
+  }>;
+  responseChangesDetected: string[];
+}
+
+export function analyzeOutboundFulfillmentCode(
+  sourceCode: string,
+  migrationData: OutboundMigrationData,
+): OutboundCodeAnalysis {
+  const deprecatedEndpoints: Array<{ endpoint: string; replacement: string }> =
+    [];
+  const breakingChanges: Array<{ change: string; explanation: string }> = [];
+  const usedAttributes: Array<{ v0: string; v1: string; notes: string }> = [];
+  const apiCalls: string[] = [];
+  const deliveryServiceLevelsUsed: Array<{ v0: string; v1: string }> = [];
+  const fulfillmentActionsUsed: Array<{ v0: string; v1: string }> = [];
+  const fulfillmentPoliciesUsed: Array<{ v0: string; v1: string }> = [];
+  const statusMappingsUsed: Array<{ v0: string; v1: string }> = [];
+  const queryParamsUsed: Array<{ v0: string; v1: string }> = [];
+  const requestBodyChangesDetected: Array<{
+    api: string;
+    field: string;
+    change: string;
+  }> = [];
+  const responseChangesDetected: string[] = [];
+
+  // Detect API method calls (camelCase, snake_case, PascalCase)
+  const apiMethodPatterns = Object.keys(migrationData.apiMappings);
+  apiMethodPatterns.forEach((method) => {
+    const regex = buildMultiCaseRegex(method);
+    if (regex.test(sourceCode)) {
+      apiCalls.push(method);
+      const mapping = migrationData.apiMappings[method];
+
+      if (mapping.status.includes("❌")) {
+        deprecatedEndpoints.push({
+          endpoint: method,
+          replacement: mapping.v1,
+        });
+        breakingChanges.push({
+          change: `${method} is not available in v2025-09-24`,
+          explanation: mapping.notes,
+        });
+      }
+    }
+  });
+
+  // Detect deprecated items (multi-case)
+  migrationData.deprecated.forEach((attr) => {
+    const regex = buildMultiCaseRegex(attr.replace(/\./g, "_"));
+    if (regex.test(sourceCode)) {
+      breakingChanges.push({
+        change: `Deprecated: ${attr}`,
+        explanation: "This is deprecated or removed in v2025-09-24",
+      });
+    }
+  });
+
+  // Detect attribute mappings (multi-case)
+  Object.entries(migrationData.attributeMappings).forEach(([v0, v1]) => {
+    const regex = buildMultiCaseRegex(v0.replace(/\./g, "_"));
+    if (regex.test(sourceCode)) {
+      usedAttributes.push({
+        v0,
+        v1,
+        notes: `Mapped from ${v0} to ${v1}`,
+      });
+    }
+  });
+
+  // Detect delivery service level values (shipping speed)
+  Object.entries(migrationData.deliveryServiceLevelMappings).forEach(
+    ([v0Speed, v1Speed]) => {
+      const regex = new RegExp(`['"\`]${v0Speed}['"\`]`, "g");
+      if (regex.test(sourceCode)) {
+        deliveryServiceLevelsUsed.push({ v0: v0Speed, v1: v1Speed });
+      }
+    },
+  );
+
+  // Detect fulfillment action values
+  Object.entries(migrationData.fulfillmentActionMappings).forEach(
+    ([v0Action, v1Action]) => {
+      const regex = new RegExp(`['"\`]${v0Action}['"\`]`, "g");
+      if (regex.test(sourceCode)) {
+        fulfillmentActionsUsed.push({ v0: v0Action, v1: v1Action });
+      }
+    },
+  );
+
+  // Detect fulfillment policy values
+  Object.entries(migrationData.fulfillmentPolicyMappings).forEach(
+    ([v0Policy, v1Policy]) => {
+      const regex = new RegExp(`['"\`]${v0Policy}['"\`]`, "g");
+      if (regex.test(sourceCode)) {
+        fulfillmentPoliciesUsed.push({ v0: v0Policy, v1: v1Policy });
+      }
+    },
+  );
+
+  // Detect status value mappings
+  Object.entries(migrationData.statusMappings.fulfillmentOrderStatus).forEach(
+    ([v0Status, v1Status]) => {
+      const regex = new RegExp(`['"\`]${v0Status}['"\`]`, "g");
+      if (regex.test(sourceCode)) {
+        statusMappingsUsed.push({ v0: v0Status, v1: v1Status });
+      }
+    },
+  );
+
+  Object.entries(migrationData.statusMappings.shipmentStatus).forEach(
+    ([v0Status, v1Status]) => {
+      // Skip if same value (already uppercase)
+      if (v0Status !== v1Status) {
+        const regex = new RegExp(`['"\`]${v0Status}['"\`]`, "g");
+        if (regex.test(sourceCode)) {
+          statusMappingsUsed.push({ v0: v0Status, v1: v1Status });
+        }
+      }
+    },
+  );
+
+  // Detect query parameter usage (multi-case)
+  Object.entries(migrationData.queryParameterMappings).forEach(
+    ([v0Param, v1Param]) => {
+      const regex = buildMultiCaseRegex(v0Param);
+      if (regex.test(sourceCode)) {
+        queryParamsUsed.push({ v0: v0Param, v1: v1Param });
+        if (v1Param.includes("Breaking")) {
+          breakingChanges.push({
+            change: `Query parameter: ${v0Param}`,
+            explanation: v1Param,
+          });
+        }
+      }
+    },
+  );
+
+  // Detect request body field usage for known APIs
+  Object.entries(migrationData.requestBodyChanges).forEach(([api, changes]) => {
+    // Check removed fields
+    changes.removed.forEach((field) => {
+      const regex = buildMultiCaseRegex(field.replace(/\[.*?\]/g, ""));
+      if (regex.test(sourceCode)) {
+        requestBodyChangesDetected.push({
+          api,
+          field,
+          change: "removed",
+        });
+        breakingChanges.push({
+          change: `Field removed in ${api}: ${field}`,
+          explanation: `The field ${field} has been removed from the ${api} request in v2025-09-24`,
+        });
+      }
+    });
+
+    // Check renamed fields
+    Object.entries(changes.renamed).forEach(([oldName, newName]) => {
+      const cleanName =
+        oldName
+          .replace(/\[.*?\]/g, "")
+          .split(".")
+          .pop() || oldName;
+      const regex = buildMultiCaseRegex(cleanName);
+      if (regex.test(sourceCode)) {
+        requestBodyChangesDetected.push({
+          api,
+          field: oldName,
+          change: `renamed to ${newName}`,
+        });
+      }
+    });
+  });
+
+  // Detect response structure usage (payload wrapper pattern)
+  if (
+    /\.payload\./g.test(sourceCode) ||
+    /\['payload'\]/g.test(sourceCode) ||
+    /\["payload"\]/g.test(sourceCode)
+  ) {
+    responseChangesDetected.push(
+      "payload wrapper detected - v2025-09-24 removes the payload wrapper",
+    );
+    breakingChanges.push({
+      change: "Response payload wrapper removed",
+      explanation:
+        "v2025-09-24 returns direct response objects without the nested payload structure. Update response parsing.",
+    });
+  }
+
+  // Detect old base path usage
+  if (
+    /\/fba\/outbound\/2020-07-01/g.test(sourceCode) ||
+    /\/fba\/outbound\/v2020-07-01/g.test(sourceCode)
+  ) {
+    breakingChanges.push({
+      change: "Base path changed",
+      explanation: `${migrationData.basePath.old} → ${migrationData.basePath.new}`,
+    });
+  }
+
+  return {
+    deprecatedEndpoints,
+    breakingChanges,
+    usedAttributes,
+    apiCalls,
+    deliveryServiceLevelsUsed,
+    fulfillmentActionsUsed,
+    fulfillmentPoliciesUsed,
+    statusMappingsUsed,
+    queryParamsUsed,
+    requestBodyChangesDetected,
+    responseChangesDetected,
+  };
+}

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/migration-assistant-tools/outbound-fulfillment-migration/code-generator.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/migration-assistant-tools/outbound-fulfillment-migration/code-generator.ts
@@ -1,0 +1,186 @@
+import { OutboundCodeAnalysis } from "./code-analyzer.js";
+import { OutboundMigrationData } from "./migration-data.js";
+
+function toSnakeCase(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+}
+
+function toPascalCase(name: string): string {
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+/**
+ * Build a regex that matches a name in camelCase, snake_case, and PascalCase.
+ */
+function buildMultiCaseRegex(camelCaseName: string): RegExp {
+  const snake = toSnakeCase(camelCaseName);
+  const pascal = toPascalCase(camelCaseName);
+  const variants = [...new Set([camelCaseName, snake, pascal])];
+  return new RegExp(`\\b(?:${variants.join("|")})\\b`, "g");
+}
+
+export function generateRefactoredOutboundCode(
+  sourceCode: string,
+  analysis: OutboundCodeAnalysis,
+  targetVersion: string,
+  _migrationData: OutboundMigrationData,
+): string {
+  let refactoredCode = sourceCode;
+
+  // Replace delivery service level values (shipping speed)
+  analysis.deliveryServiceLevelsUsed.forEach((speed) => {
+    const v0Pattern = new RegExp(`(['"\`])${speed.v0}\\1`, "g");
+    refactoredCode = refactoredCode.replace(v0Pattern, `$1${speed.v1}$1`);
+  });
+
+  // Replace fulfillment action values
+  analysis.fulfillmentActionsUsed.forEach((action) => {
+    const v0Pattern = new RegExp(`(['"\`])${action.v0}\\1`, "g");
+    refactoredCode = refactoredCode.replace(v0Pattern, `$1${action.v1}$1`);
+  });
+
+  // Replace fulfillment policy values
+  analysis.fulfillmentPoliciesUsed.forEach((policy) => {
+    const v0Pattern = new RegExp(`(['"\`])${policy.v0}\\1`, "g");
+    refactoredCode = refactoredCode.replace(v0Pattern, `$1${policy.v1}$1`);
+  });
+
+  // Replace status values
+  analysis.statusMappingsUsed.forEach((status) => {
+    const v0Pattern = new RegExp(`(['"\`])${status.v0}\\1`, "g");
+    refactoredCode = refactoredCode.replace(v0Pattern, `$1${status.v1}$1`);
+  });
+
+  // Replace query parameters (handles camelCase, snake_case, PascalCase)
+  analysis.queryParamsUsed.forEach((param) => {
+    if (!param.v1.includes("Breaking")) {
+      const v1ParamName = param.v1.split(" ")[0];
+      const v0Pattern = buildMultiCaseRegex(param.v0);
+      refactoredCode = refactoredCode.replace(v0Pattern, v1ParamName);
+    }
+  });
+
+  // Replace API method calls with new names
+  const apiReplacements: Record<string, string> = {
+    createFulfillmentOrder: "createOrder",
+    getFulfillmentOrder: "getOrder",
+    updateFulfillmentOrder: "updateOrder",
+    cancelFulfillmentOrder: "cancelOrder",
+    listAllFulfillmentOrders: "listOrders",
+    getFulfillmentPreview: "getOrderPreview",
+    submitFulfillmentOrderStatusUpdate: "updateOrderStatus",
+    deliveryOffers: "getOffers",
+  };
+
+  Object.entries(apiReplacements).forEach(([v0Method, v1Method]) => {
+    const regex = buildMultiCaseRegex(v0Method);
+    refactoredCode = refactoredCode.replace(regex, v1Method);
+  });
+
+  // Replace key attribute names from request bodies
+  const attributeReplacements: Record<string, string> = {
+    sellerFulfillmentOrderId: "orderId",
+    shippingSpeedCategory: "deliveryServiceLevel",
+    destinationAddress: "destination",
+    fulfillmentOrderStatus: "status",
+    statusUpdatedDate: "statusUpdateTime",
+    receivedDate: "receiveTime",
+    fulfillmentShipments: "shipments",
+    fulfillmentShipmentPackage: "shipmentPackages",
+    fulfillmentCenterId: "fulfillmentCenter",
+    shippingSpeedCategories: "deliveryServiceLevels",
+    queryStartDate: "updatedAfter",
+    fulfillmentPreviews: "plannedShipments",
+    fulfillmentPreviewShipments: "offers",
+    earliestArrivalDate: "deliveryInterval.startTime",
+    latestArrivalDate: "deliveryInterval.endTime",
+  };
+
+  Object.entries(attributeReplacements).forEach(([v0Attr, v1Attr]) => {
+    const regex = buildMultiCaseRegex(v0Attr);
+    const simpleName = v1Attr.includes(".") ? v1Attr : v1Attr;
+    refactoredCode = refactoredCode.replace(regex, simpleName);
+  });
+
+  // Add comments for deprecated endpoints (multi-case)
+  analysis.deprecatedEndpoints.forEach((endpoint) => {
+    const regex = buildMultiCaseRegex(endpoint.endpoint);
+    refactoredCode = refactoredCode.replace(
+      regex,
+      (match) =>
+        `${match} /* ⚠️ ${endpoint.replacement} - not available in v2025-09-24 */`,
+    );
+  });
+
+  // Update base path
+  refactoredCode = refactoredCode.replace(
+    /\/fba\/outbound\/2020-07-01/g,
+    "/fulfillment/outbound/2025-09-24",
+  );
+  refactoredCode = refactoredCode.replace(
+    /\/fba\/outbound\/v2020-07-01/g,
+    "/fulfillment/outbound/2025-09-24",
+  );
+
+  // Update endpoint paths
+  refactoredCode = refactoredCode.replace(
+    /\/fulfillmentOrders\/preview/g,
+    "/previews",
+  );
+  refactoredCode = refactoredCode.replace(/\/fulfillmentOrders/g, "/orders");
+  refactoredCode = refactoredCode.replace(/\/deliveryOffers/g, "/offers");
+
+  // Build summary notes
+  const deliveryServiceLevelNotes =
+    analysis.deliveryServiceLevelsUsed.length > 0
+      ? `\n * Delivery service levels updated: ${analysis.deliveryServiceLevelsUsed.map((s) => `${s.v0} → ${s.v1}`).join(", ")}`
+      : "";
+
+  const fulfillmentActionNotes =
+    analysis.fulfillmentActionsUsed.length > 0
+      ? `\n * Fulfillment actions updated: ${analysis.fulfillmentActionsUsed.map((a) => `${a.v0} → ${a.v1}`).join(", ")}`
+      : "";
+
+  const fulfillmentPolicyNotes =
+    analysis.fulfillmentPoliciesUsed.length > 0
+      ? `\n * Fulfillment policies updated: ${analysis.fulfillmentPoliciesUsed.map((p) => `${p.v0} → ${p.v1}`).join(", ")}`
+      : "";
+
+  const statusNotes =
+    analysis.statusMappingsUsed.length > 0
+      ? `\n * Status values updated: ${analysis.statusMappingsUsed.map((s) => `${s.v0} → ${s.v1}`).join(", ")}`
+      : "";
+
+  const queryParamNotes =
+    analysis.queryParamsUsed.length > 0
+      ? `\n * Query parameters updated: ${analysis.queryParamsUsed.map((p) => `${p.v0} → ${p.v1.split(" ")[0]}`).join(", ")}`
+      : "";
+
+  const responseNotes =
+    analysis.responseChangesDetected.length > 0
+      ? `\n * Response changes: ${analysis.responseChangesDetected.join(", ")}`
+      : "";
+
+  // Add migration header comment
+  const header = `/**
+ * 🔄 Migrated from Fulfillment Outbound API v2020-07-01 to ${targetVersion}
+ * Base path: /fba/outbound/2020-07-01 → /fulfillment/outbound/2025-09-24
+ * 
+ * Migration Summary:
+ * - ${analysis.usedAttributes.length} attributes updated
+ * - ${analysis.apiCalls.length} API methods analyzed
+ * - ${analysis.breakingChanges.length} breaking changes identified
+ * - ${analysis.requestBodyChangesDetected.length} request body changes detected${deliveryServiceLevelNotes}${fulfillmentActionNotes}${fulfillmentPolicyNotes}${statusNotes}${queryParamNotes}${responseNotes}
+ * 
+ * ⚠️ Notes:
+ * - getPackageTrackingDetails moved to Amazon Tracking API
+ * - getFeatures/getFeatureSKU/getFeatureInventory deprecated (use getOrderPreview)
+ * - createFulfillmentReturn/listReturnReasonCodes deprecated
+ * - Response objects no longer wrapped in payload
+ * - All enum values now use SCREAMING_SNAKE_CASE
+ */
+
+`;
+
+  return header + refactoredCode;
+}

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/migration-assistant-tools/outbound-fulfillment-migration/guidance-formatter.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/migration-assistant-tools/outbound-fulfillment-migration/guidance-formatter.ts
@@ -1,0 +1,322 @@
+import { OutboundMigrationData } from "./migration-data.js";
+
+export function formatOutboundGeneralGuidance(
+  migrationData: OutboundMigrationData,
+): string {
+  let guidance = `# 🔄 Fulfillment Outbound API Migration Guide: v2020-07-01 → v2025-09-24\n\n`;
+
+  guidance += `## 📋 Overview\n\n`;
+  guidance += `This guide helps you migrate from Fulfillment Outbound API v2020-07-01 to v2025-09-24.\n`;
+  guidance += `The new version introduces a modern scalable interface with new capabilities including `;
+  guidance += `partner account credentials, channel-based feature configuration, and enhanced notifications.\n\n`;
+
+  guidance += `**Key Changes:**\n`;
+  guidance += `- Base path changed: \`/fba/outbound/2020-07-01\` → \`/fulfillment/outbound/2025-09-24\`\n`;
+  guidance += `- New \`x-amzn-fulfillment-service-id\` header for multi-site API scoping\n`;
+  guidance += `- Operation renames (e.g., createFulfillmentOrder → createOrder)\n`;
+  guidance += `- All enum values standardized to SCREAMING_SNAKE_CASE\n`;
+  guidance += `- Response objects no longer wrapped in \`payload\` structure\n`;
+  guidance += `- getPackageTrackingDetails moved to Amazon Tracking API\n`;
+  guidance += `- getFeatures/getFeatureSKU/getFeatureInventory deprecated\n`;
+  guidance += `- createFulfillmentReturn/listReturnReasonCodes deprecated\n`;
+  guidance += `- New FULFILLMENT_ORDER_STATUS notification with package-level updates\n`;
+  guidance += `- Webhook subscription support and CEL-based event filtering\n\n`;
+
+  // Migration Benefits
+  guidance += `## 🎯 Migration Benefits\n\n`;
+  migrationData.migrationBenefits.forEach((benefit) => {
+    guidance += `- ${benefit}\n`;
+  });
+  guidance += `\n`;
+
+  // API Availability
+  guidance += `## 🔌 API Method Mapping\n\n`;
+  guidance += `### ✅ Available in v2025-09-24:\n\n`;
+  Object.entries(migrationData.apiMappings).forEach(([v0Method, mapping]) => {
+    if (mapping.status.includes("✅")) {
+      guidance += `- **${v0Method}** → \`${mapping.v1}\`\n`;
+      guidance += `  ${mapping.notes}\n\n`;
+    }
+  });
+
+  guidance += `### ❌ NOT Available in v2025-09-24:\n\n`;
+  Object.entries(migrationData.apiMappings).forEach(([v0Method, mapping]) => {
+    if (mapping.status.includes("❌")) {
+      guidance += `- **${v0Method}** → ${mapping.v1}\n`;
+      guidance += `  ${mapping.notes}\n\n`;
+    }
+  });
+
+  // Delivery Service Level Mappings
+  guidance += `## 🚚 Delivery Service Level Mappings\n\n`;
+  guidance += `\`shippingSpeedCategory\` is renamed to \`deliveryServiceLevel\` with uppercase values:\n\n`;
+  Object.entries(migrationData.deliveryServiceLevelMappings).forEach(
+    ([v0, v1]) => {
+      guidance += `- \`"${v0}"\` → \`"${v1}"\`\n`;
+    },
+  );
+  guidance += `\n`;
+
+  // Fulfillment Action & Policy Mappings
+  guidance += `## ⚙️ Fulfillment Action & Policy Mappings\n\n`;
+  guidance += `**fulfillmentAction** (same field name, new enum values):\n\n`;
+  Object.entries(migrationData.fulfillmentActionMappings).forEach(
+    ([v0, v1]) => {
+      guidance += `- \`"${v0}"\` → \`"${v1}"\`\n`;
+    },
+  );
+  guidance += `\n**fulfillmentPolicy** (same field name, new enum values):\n\n`;
+  Object.entries(migrationData.fulfillmentPolicyMappings).forEach(
+    ([v0, v1]) => {
+      guidance += `- \`"${v0}"\` → \`"${v1}"\`\n`;
+    },
+  );
+  guidance += `\n`;
+
+  // Status Mappings
+  guidance += `## 🔄 Status Value Mappings\n\n`;
+  guidance += `### Fulfillment Order Status:\n\n`;
+  Object.entries(migrationData.statusMappings.fulfillmentOrderStatus).forEach(
+    ([v0, v1]) => {
+      guidance += `- \`"${v0}"\` → \`"${v1}"\`\n`;
+    },
+  );
+  guidance += `\n### Shipment Status:\n\n`;
+  Object.entries(migrationData.statusMappings.shipmentStatus).forEach(
+    ([v0, v1]) => {
+      guidance += `- \`"${v0}"\` → \`"${v1}"\`\n`;
+    },
+  );
+  guidance += `\n### Package Status (New in v2025-09-24):\n\n`;
+  Object.entries(migrationData.statusMappings.packageStatus).forEach(
+    ([, v1]) => {
+      guidance += `- \`"${v1}"\`\n`;
+    },
+  );
+  guidance += `\n`;
+
+  // Request Body Changes
+  guidance += `## 📝 Request Body Changes\n\n`;
+  Object.entries(migrationData.requestBodyChanges).forEach(([api, changes]) => {
+    guidance += `### ${api}\n\n`;
+
+    if (changes.removed.length > 0) {
+      guidance += `**Removed fields:**\n`;
+      changes.removed.forEach((field) => {
+        guidance += `- ❌ \`${field}\`\n`;
+      });
+      guidance += `\n`;
+    }
+
+    if (Object.keys(changes.renamed).length > 0) {
+      guidance += `**Renamed fields:**\n`;
+      Object.entries(changes.renamed).forEach(([oldName, newName]) => {
+        guidance += `- \`${oldName}\` → \`${newName}\`\n`;
+      });
+      guidance += `\n`;
+    }
+
+    if (changes.added.length > 0) {
+      guidance += `**New fields:**\n`;
+      changes.added.forEach((field) => {
+        guidance += `- ✨ \`${field}\`\n`;
+      });
+      guidance += `\n`;
+    }
+
+    if (changes.enumChanges && Object.keys(changes.enumChanges).length > 0) {
+      guidance += `**Enum value changes:**\n`;
+      Object.entries(changes.enumChanges).forEach(([field, mapping]) => {
+        guidance += `- \`${field}\`: ${mapping}\n`;
+      });
+      guidance += `\n`;
+    }
+  });
+
+  // Response Changes
+  guidance += `## 📤 Response Structure Changes\n\n`;
+  guidance += `**Key structural change:** All responses remove the \`payload\` wrapper. Access data directly.\n\n`;
+  Object.entries(migrationData.responseChanges).forEach(([api, changes]) => {
+    guidance += `### ${api}\n\n`;
+    if (changes.structureChanges.length > 0) {
+      changes.structureChanges.forEach((change) => {
+        guidance += `- ${change}\n`;
+      });
+      guidance += `\n`;
+    }
+    if (Object.keys(changes.renamed).length > 0) {
+      guidance += `Field renames:\n`;
+      Object.entries(changes.renamed).forEach(([oldName, newName]) => {
+        guidance += `- \`${oldName}\` → \`${newName}\`\n`;
+      });
+      guidance += `\n`;
+    }
+  });
+
+  // Authorization
+  guidance += `## 🔐 Authorization\n\n`;
+  guidance += `If your application uses a single authorization token for multi-site APIs, include the `;
+  guidance += `\`x-amzn-fulfillment-service-id\` header in all non-tenancy API requests.\n\n`;
+  guidance += `This header is **optional** if your app uses a regular authorization token scoped to a single merchant account.\n\n`;
+  guidance += `\`\`\`\n`;
+  guidance += `x-amzn-fulfillment-service-id: FS01-o8vlfw8b1tiu1\n`;
+  guidance += `x-amz-access-token: Atza|IwEBIPmyMZBjeTaN...\n`;
+  guidance += `\`\`\`\n\n`;
+
+  // Tenancy Operations
+  guidance += `## 🏢 New Tenancy Operations\n\n`;
+  guidance += `${migrationData.tenancyOperations.description}\n\n`;
+  Object.entries(migrationData.tenancyOperations.operations).forEach(
+    ([name, op]) => {
+      guidance += `- **${name}**: \`${op.endpoint}\`\n`;
+      guidance += `  ${op.description}\n\n`;
+    },
+  );
+
+  // Notifications
+  guidance += `## 🔔 Enhanced Notifications\n\n`;
+  guidance += `${migrationData.notifications.description}\n\n`;
+  guidance += `**Event Types:**\n\n`;
+  Object.entries(migrationData.notifications.eventTypes).forEach(
+    ([eventType, info]) => {
+      guidance += `- **${eventType}**: ${info.description}\n`;
+      guidance += `  Statuses: ${info.statuses.join(", ")}\n\n`;
+    },
+  );
+  guidance += `**Webhook support:** ${migrationData.notifications.webhookSupport ? "Yes" : "No"}\n`;
+  guidance += `**CEL filter expressions:** ${migrationData.notifications.sbqFilterSupport ? "Yes" : "No"}\n\n`;
+
+  // Code Examples
+  guidance += `## 💻 Code Examples\n\n`;
+
+  guidance += `### Creating a Fulfillment Order\n\n`;
+  guidance += `**v2020-07-01:**\n`;
+  guidance += `\`\`\`javascript\n`;
+  guidance += `POST /fba/outbound/2020-07-01/fulfillmentOrders\n\n`;
+  guidance += `{\n`;
+  guidance += `  "sellerFulfillmentOrderId": "ABC123",\n`;
+  guidance += `  "shippingSpeedCategory": "Standard",\n`;
+  guidance += `  "fulfillmentAction": "Ship",\n`;
+  guidance += `  "fulfillmentPolicy": "FillAllAvailable",\n`;
+  guidance += `  "destinationAddress": {\n`;
+  guidance += `    "name": "Recipient Name",\n`;
+  guidance += `    "addressLine1": "1000 Winthrop Ave N",\n`;
+  guidance += `    "city": "Seattle",\n`;
+  guidance += `    "stateOrRegion": "WA",\n`;
+  guidance += `    "postalCode": "98103",\n`;
+  guidance += `    "countryCode": "US"\n`;
+  guidance += `  },\n`;
+  guidance += `  "marketplaceId": "ATVPDKIKX0DER",\n`;
+  guidance += `  "items": [{\n`;
+  guidance += `    "sellerFulfillmentOrderItemId": "item1",\n`;
+  guidance += `    "sellerSKU": "SKU1",\n`;
+  guidance += `    "quantity": 2\n`;
+  guidance += `  }],\n`;
+  guidance += `  "featureConstraints": [{\n`;
+  guidance += `    "featureName": "BLANK_BOX",\n`;
+  guidance += `    "featureFulfillmentPolicy": "Required"\n`;
+  guidance += `  }]\n`;
+  guidance += `}\n`;
+  guidance += `\`\`\`\n\n`;
+
+  guidance += `**v2025-09-24:**\n`;
+  guidance += `\`\`\`javascript\n`;
+  guidance += `POST /fulfillment/outbound/2025-09-24/orders\n\n`;
+  guidance += `{\n`;
+  guidance += `  "orderId": "ABC123",\n`;
+  guidance += `  "deliveryServiceLevel": "STANDARD",\n`;
+  guidance += `  "fulfillmentAction": "SHIP",\n`;
+  guidance += `  "fulfillmentPolicy": "FILL_ALL_AVAILABLE",\n`;
+  guidance += `  "destination": {\n`;
+  guidance += `    "deliveryAddress": {\n`;
+  guidance += `      "name": "Recipient Name",\n`;
+  guidance += `      "addressLine1": "1000 Winthrop Ave N",\n`;
+  guidance += `      "city": "Seattle",\n`;
+  guidance += `      "stateOrRegion": "WA",\n`;
+  guidance += `      "postalCode": "98103",\n`;
+  guidance += `      "countryCode": "US"\n`;
+  guidance += `    }\n`;
+  guidance += `  },\n`;
+  guidance += `  "origin": { "countryCode": "US" },\n`;
+  guidance += `  "lineItems": [{\n`;
+  guidance += `    "lineItemId": "item1",\n`;
+  guidance += `    "product": {\n`;
+  guidance += `      "productIdentifier": { "amazonSku": "SKU1" }\n`;
+  guidance += `    },\n`;
+  guidance += `    "amount": { "unitOfMeasure": "EACHES", "value": "2.0" }\n`;
+  guidance += `  }],\n`;
+  guidance += `  "services": {\n`;
+  guidance += `    "packaging": { "blankBox": "REQUIRED" }\n`;
+  guidance += `  }\n`;
+  guidance += `}\n`;
+  guidance += `\`\`\`\n\n`;
+
+  guidance += `### Getting a Fulfillment Order\n\n`;
+  guidance += `**v2020-07-01:**\n`;
+  guidance += `\`\`\`javascript\n`;
+  guidance += `const response = await getFulfillmentOrder(orderId);\n`;
+  guidance += `const status = response.payload.fulfillmentOrder.fulfillmentOrderStatus;\n`;
+  guidance += `const items = response.payload.fulfillmentOrderItems;\n`;
+  guidance += `const shipments = response.payload.fulfillmentShipments;\n`;
+  guidance += `\`\`\`\n\n`;
+  guidance += `**v2025-09-24:**\n`;
+  guidance += `\`\`\`javascript\n`;
+  guidance += `const response = await getOrder(orderId);\n`;
+  guidance += `const status = response.fulfillmentOrder.status; // No payload wrapper\n`;
+  guidance += `const items = response.fulfillmentOrder.lineItems; // Nested in order\n`;
+  guidance += `const shipments = response.fulfillmentOrder.shipments; // Nested in order\n`;
+  guidance += `\`\`\`\n\n`;
+
+  guidance += `### Webhook Subscription for Notifications\n\n`;
+  guidance += `\`\`\`javascript\n`;
+  guidance += `// 1. Create webhook destination\n`;
+  guidance += `POST /notifications/v1/destinations\n`;
+  guidance += `{\n`;
+  guidance += `  "name": "mcf-tracking-webhook",\n`;
+  guidance += `  "resourceSpecification": {\n`;
+  guidance += `    "webhook": {\n`;
+  guidance += `      "url": "https://mydomain.com/mcf-events",\n`;
+  guidance += `      "signatureType": "RSA"\n`;
+  guidance += `    }\n`;
+  guidance += `  }\n`;
+  guidance += `}\n\n`;
+  guidance += `// 2. Subscribe to FULFILLMENT_ORDER_STATUS\n`;
+  guidance += `POST /notifications/v1/subscriptions/FULFILLMENT_ORDER_STATUS\n`;
+  guidance += `{\n`;
+  guidance += `  "payloadVersion": "2025-09-24",\n`;
+  guidance += `  "destinationId": "WEBHOOK_DESTINATION_ID"\n`;
+  guidance += `}\n`;
+  guidance += `\`\`\`\n\n`;
+
+  // Migration Checklist
+  guidance += `## ✅ Migration Checklist\n\n`;
+  guidance += `- [ ] Update base path: \`/fba/outbound/2020-07-01\` → \`/fulfillment/outbound/2025-09-24\`\n`;
+  guidance += `- [ ] Rename API operations (createFulfillmentOrder → createOrder, etc.)\n`;
+  guidance += `- [ ] Update endpoint paths (/fulfillmentOrders → /orders, /fulfillmentOrders/preview → /previews)\n`;
+  guidance += `- [ ] Update enum values to SCREAMING_SNAKE_CASE\n`;
+  guidance += `- [ ] Rename request body fields (sellerFulfillmentOrderId → orderId, items → lineItems, etc.)\n`;
+  guidance += `- [ ] Replace marketplaceId with origin.countryCode\n`;
+  guidance += `- [ ] Update response parsing to remove payload wrapper\n`;
+  guidance += `- [ ] Update status field names (fulfillmentOrderStatus → status)\n`;
+  guidance += `- [ ] Handle pagination changes (nextToken → pageToken)\n`;
+  guidance += `- [ ] Add x-amzn-fulfillment-service-id header if using multi-site APIs\n`;
+  guidance += `- [ ] Replace getFeatureInventory with getOrderPreview for fulfillability checks\n`;
+  guidance += `- [ ] Migrate getPackageTrackingDetails to Amazon Tracking API (or keep v2020-07-01)\n`;
+  guidance += `- [ ] Handle deprecated return operations (keep v2020-07-01 for returns)\n`;
+  guidance += `- [ ] Consider webhook notifications instead of polling\n`;
+  guidance += `- [ ] Test with sandbox environment (new status simulation milestones)\n`;
+  guidance += `- [ ] Update TypeScript types/interfaces\n\n`;
+
+  // Resources
+  guidance += `## 📚 Resources\n\n`;
+  guidance += `- [SP-API Fulfillment Outbound v2025-09-24 Documentation](https://developer-docs.amazon.com/sp-api/docs/fulfillment-outbound-api-v2025-reference)\n`;
+  guidance += `- [MCF API Developer Guide](https://developer-docs.amazon.com/sp-api/docs/mcf-api-developer-guide)\n`;
+  guidance += `- [SP-API Developer Guide](https://developer-docs.amazon.com/sp-api/)\n\n`;
+
+  guidance += `## 🔍 Need More Help?\n\n`;
+  guidance += `- **Code Analysis:** Provide your source code for detailed analysis and automated refactoring\n`;
+  guidance += `- **Specific Attributes:** Ask about specific v2020-07-01 attributes for detailed mapping\n`;
+  guidance += `- **API Methods:** Ask about specific API methods for migration guidance\n`;
+
+  return guidance;
+}

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/migration-assistant-tools/outbound-fulfillment-migration/migration-data.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/migration-assistant-tools/outbound-fulfillment-migration/migration-data.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "fs";
+
+export interface ApiMapping {
+  v1: string;
+  status: string;
+  notes: string;
+}
+
+export interface StatusMappings {
+  fulfillmentOrderStatus: Record<string, string>;
+  shipmentStatus: Record<string, string>;
+  packageStatus: Record<string, string>;
+}
+
+export interface RequestBodyChange {
+  removed: string[];
+  renamed: Record<string, string>;
+  added: string[];
+  enumChanges?: Record<string, string>;
+}
+
+export interface ResponseChange {
+  renamed: Record<string, string>;
+  structureChanges: string[];
+}
+
+export interface TenancyOperation {
+  endpoint: string;
+  description: string;
+}
+
+export interface NotificationEventType {
+  statuses: string[];
+  description: string;
+}
+
+export interface Notifications {
+  description: string;
+  eventTypes: Record<string, NotificationEventType>;
+  webhookSupport: boolean;
+  sbqFilterSupport: boolean;
+  payloadVersion: string;
+}
+
+export interface OutboundMigrationData {
+  deprecated: string[];
+  notSupported: string[];
+  attributeMappings: Record<string, string>;
+  newFeatures: string[];
+  apiMappings: Record<string, ApiMapping>;
+  deliveryServiceLevelMappings: Record<string, string>;
+  fulfillmentActionMappings: Record<string, string>;
+  fulfillmentPolicyMappings: Record<string, string>;
+  statusMappings: StatusMappings;
+  queryParameterMappings: Record<string, string>;
+  requestBodyChanges: Record<string, RequestBodyChange>;
+  responseChanges: Record<string, ResponseChange>;
+  basePath: { old: string; new: string };
+  tenancyOperations: {
+    description: string;
+    operations: Record<string, TenancyOperation>;
+  };
+  notifications: Notifications;
+  migrationBenefits: string[];
+}
+
+export function getOutboundFulfillmentMigrationData(
+  resourcePath: string,
+): OutboundMigrationData {
+  const jsonData = JSON.parse(readFileSync(resourcePath, "utf-8"));
+
+  return {
+    deprecated: jsonData.deprecated,
+    notSupported: jsonData.notSupported,
+    attributeMappings: jsonData.attributeMappings,
+    newFeatures: jsonData.newFeatures,
+    apiMappings: jsonData.apiMappings,
+    deliveryServiceLevelMappings: jsonData.deliveryServiceLevelMappings,
+    fulfillmentActionMappings: jsonData.fulfillmentActionMappings,
+    fulfillmentPolicyMappings: jsonData.fulfillmentPolicyMappings,
+    statusMappings: jsonData.statusMappings,
+    queryParameterMappings: jsonData.queryParameterMappings,
+    requestBodyChanges: jsonData.requestBodyChanges,
+    responseChanges: jsonData.responseChanges,
+    basePath: jsonData.basePath,
+    tenancyOperations: jsonData.tenancyOperations,
+    notifications: jsonData.notifications,
+    migrationBenefits: jsonData.migrationBenefits,
+  };
+}

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/migration-assistant-tools/outbound-fulfillment-migration/report-formatter.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/migration-assistant-tools/outbound-fulfillment-migration/report-formatter.ts
@@ -1,0 +1,178 @@
+import { OutboundCodeAnalysis } from "./code-analyzer.js";
+import { OutboundMigrationData } from "./migration-data.js";
+
+export function formatOutboundAnalysisReport(
+  analysis: OutboundCodeAnalysis,
+  migrationData: OutboundMigrationData,
+): string {
+  let report = `# 🔍 Outbound Fulfillment Migration Analysis Report\n\n`;
+  report += `## 📊 Summary\n\n`;
+  report += `- **API Calls Found:** ${analysis.apiCalls.length}\n`;
+  report += `- **Attributes to Update:** ${analysis.usedAttributes.length}\n`;
+  report += `- **Breaking Changes:** ${analysis.breakingChanges.length}\n`;
+  report += `- **Deprecated Endpoints:** ${analysis.deprecatedEndpoints.length}\n`;
+  report += `- **Delivery Service Levels to Update:** ${analysis.deliveryServiceLevelsUsed.length}\n`;
+  report += `- **Fulfillment Actions to Update:** ${analysis.fulfillmentActionsUsed.length}\n`;
+  report += `- **Fulfillment Policies to Update:** ${analysis.fulfillmentPoliciesUsed.length}\n`;
+  report += `- **Status Values to Update:** ${analysis.statusMappingsUsed.length}\n`;
+  report += `- **Query Parameters to Update:** ${analysis.queryParamsUsed.length}\n`;
+  report += `- **Request Body Changes:** ${analysis.requestBodyChangesDetected.length}\n`;
+  report += `- **Response Structure Changes:** ${analysis.responseChangesDetected.length}\n\n`;
+
+  if (analysis.deprecatedEndpoints.length > 0) {
+    report += `## ❌ Deprecated/Moved Endpoints\n\n`;
+    analysis.deprecatedEndpoints.forEach((endpoint) => {
+      report += `- **${endpoint.endpoint}** → ${endpoint.replacement}\n`;
+    });
+    report += `\n`;
+  }
+
+  if (analysis.breakingChanges.length > 0) {
+    report += `## ⚠️ Breaking Changes\n\n`;
+    analysis.breakingChanges.forEach((change, index) => {
+      report += `${index + 1}. **${change.change}**\n`;
+      report += `   ${change.explanation}\n\n`;
+    });
+  }
+
+  if (analysis.usedAttributes.length > 0) {
+    report += `## 🗺️ Attribute Mappings\n\n`;
+    analysis.usedAttributes.forEach((attr) => {
+      report += `- \`${attr.v0}\` → \`${attr.v1}\`\n`;
+    });
+    report += `\n`;
+  }
+
+  if (analysis.deliveryServiceLevelsUsed.length > 0) {
+    report += `## 🚚 Delivery Service Level Updates\n\n`;
+    analysis.deliveryServiceLevelsUsed.forEach((speed) => {
+      report += `- \`"${speed.v0}"\` → \`"${speed.v1}"\`\n`;
+    });
+    report += `\n`;
+  }
+
+  if (analysis.fulfillmentActionsUsed.length > 0) {
+    report += `## ⚙️ Fulfillment Action Updates\n\n`;
+    analysis.fulfillmentActionsUsed.forEach((action) => {
+      report += `- \`"${action.v0}"\` → \`"${action.v1}"\`\n`;
+    });
+    report += `\n`;
+  }
+
+  if (analysis.fulfillmentPoliciesUsed.length > 0) {
+    report += `## 📋 Fulfillment Policy Updates\n\n`;
+    analysis.fulfillmentPoliciesUsed.forEach((policy) => {
+      report += `- \`"${policy.v0}"\` → \`"${policy.v1}"\`\n`;
+    });
+    report += `\n`;
+  }
+
+  if (analysis.statusMappingsUsed.length > 0) {
+    report += `## 🔄 Status Value Updates\n\n`;
+    analysis.statusMappingsUsed.forEach((status) => {
+      report += `- \`"${status.v0}"\` → \`"${status.v1}"\`\n`;
+    });
+    report += `\n`;
+  }
+
+  if (analysis.queryParamsUsed.length > 0) {
+    report += `## 🔍 Query Parameter Updates\n\n`;
+    analysis.queryParamsUsed.forEach((param) => {
+      if (param.v1.includes("Breaking")) {
+        report += `- \`${param.v0}\` → ⚠️ ${param.v1}\n`;
+      } else {
+        report += `- \`${param.v0}\` → \`${param.v1}\`\n`;
+      }
+    });
+    report += `\n`;
+  }
+
+  if (analysis.requestBodyChangesDetected.length > 0) {
+    report += `## 📝 Request Body Changes\n\n`;
+    analysis.requestBodyChangesDetected.forEach((change) => {
+      if (change.change === "removed") {
+        report += `- ❌ \`${change.field}\` (${change.api}) - Removed in v2025-09-24\n`;
+      } else {
+        report += `- 🔄 \`${change.field}\` (${change.api}) - ${change.change}\n`;
+      }
+    });
+    report += `\n`;
+  }
+
+  if (analysis.responseChangesDetected.length > 0) {
+    report += `## 📤 Response Structure Changes\n\n`;
+    analysis.responseChangesDetected.forEach((change) => {
+      report += `- ⚠️ ${change}\n`;
+    });
+    report += `\n`;
+  }
+
+  if (analysis.apiCalls.length > 0) {
+    report += `## 🔌 API Methods Detected\n\n`;
+    analysis.apiCalls.forEach((method) => {
+      const mapping = migrationData.apiMappings[method];
+      const status = mapping?.status || "Unknown";
+      report += `- **${method}** - ${status}\n`;
+      if (mapping?.notes) {
+        report += `  ${mapping.notes}\n`;
+      }
+    });
+    report += `\n`;
+  }
+
+  // Migration Benefits
+  report += `## 🎯 Migration Benefits\n\n`;
+  migrationData.migrationBenefits.forEach((benefit) => {
+    report += `- ${benefit}\n`;
+  });
+  report += `\n`;
+
+  report += `## ✅ Migration Checklist\n\n`;
+  report += `- [ ] Update base path: /fba/outbound/2020-07-01 → /fulfillment/outbound/2025-09-24\n`;
+  report += `- [ ] Rename API operations to new names\n`;
+  report += `- [ ] Update endpoint paths (/fulfillmentOrders → /orders)\n`;
+  report += `- [ ] Update enum values to SCREAMING_SNAKE_CASE\n`;
+  report += `- [ ] Rename request body fields\n`;
+  report += `- [ ] Remove payload wrapper from response parsing\n`;
+  report += `- [ ] Update status field names and values\n`;
+  report += `- [ ] Handle pagination changes (nextToken → pageToken)\n`;
+  report += `- [ ] Replace deprecated operations with alternatives\n`;
+  report += `- [ ] Add x-amzn-fulfillment-service-id header if needed\n`;
+  report += `- [ ] Test with sandbox environment\n`;
+  report += `- [ ] Update TypeScript types/interfaces\n\n`;
+
+  return report;
+}
+
+export function formatOutboundMigrationReport(
+  analysis: OutboundCodeAnalysis,
+  refactoredCode: string,
+  migrationData: OutboundMigrationData,
+): string {
+  let report = formatOutboundAnalysisReport(analysis, migrationData);
+
+  report += `\n---\n\n`;
+  report += `## 💻 Refactored Code\n\n`;
+  report += `\`\`\`javascript\n${refactoredCode}\n\`\`\`\n\n`;
+
+  report += `## 🧪 Testing Recommendations\n\n`;
+  report += `1. **Unit Tests:** Update test cases to match new v2025-09-24 response structure (no payload wrapper)\n`;
+  report += `2. **Integration Tests:** Test with SP-API sandbox environment\n`;
+  report += `3. **Delivery Service Levels:** Verify SCREAMING_SNAKE_CASE values work correctly\n`;
+  report += `4. **Fulfillment Actions/Policies:** Verify new enum values (SHIP, FILL_ALL_AVAILABLE, etc.)\n`;
+  report += `5. **Status Values:** Verify status comparisons use new values (COMPLETE, PROCESSING, etc.)\n`;
+  report += `6. **Request Bodies:** Verify renamed fields are accepted (orderId, lineItems, etc.)\n`;
+  report += `7. **Response Parsing:** Verify direct object access without payload wrapper\n`;
+  report += `8. **Pagination:** Test pageToken handling\n`;
+  report += `9. **Sandbox Simulation:** Test new delivery milestones (IN_TRANSIT, DELAYED, DELIVERED)\n`;
+  report += `10. **Webhook Integration:** Test notification delivery if migrating from polling\n`;
+  report += `11. **Multi-site:** Test x-amzn-fulfillment-service-id header if applicable\n`;
+  report += `12. **Backward Compatibility:** Ensure v2020-07-01 fallback works for deprecated operations\n\n`;
+
+  report += `## 📚 Additional Resources\n\n`;
+  report += `- [SP-API Fulfillment Outbound v2025-09-24 Documentation](https://developer-docs.amazon.com/sp-api/docs/fulfillment-outbound-api-v2025-reference)\n`;
+  report += `- [MCF API Developer Guide](https://developer-docs.amazon.com/sp-api/docs/mcf-api-developer-guide)\n`;
+  report += `- Use \`sp_api_migration_assistant\` tool for detailed attribute mappings\n\n`;
+
+  return report;
+}

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/zod-schemas/migration-schemas.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/zod-schemas/migration-schemas.ts
@@ -33,10 +33,14 @@ export const migrationAssistantSchema = z.object({
     ),
   source_version: z
     .string()
-    .describe("Current API version (e.g., 'orders-v0')"),
+    .describe(
+      "Current API version (e.g., 'orders-v0', 'fulfillment-outbound-v2020-07-01')",
+    ),
   target_version: z
     .string()
-    .describe("Target API version (e.g., 'orders-2026-01-01')"),
+    .describe(
+      "Target API version (e.g., 'orders-2026-01-01', 'fulfillment-outbound-2025-09-24')",
+    ),
   language: z
     .string()
     .optional()

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/tests/tools/outbound-fulfillment-migration-tools.test.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/tests/tools/outbound-fulfillment-migration-tools.test.ts
@@ -1,0 +1,444 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { SPAPIMigrationAssistantTool } from "../../src/tools/migration-assistant-tools/migration-tools";
+import { join } from "path";
+
+const resourcesDir = join(process.cwd(), "src", "resources");
+
+describe("SPAPIMigrationAssistantTool - Outbound Fulfillment", () => {
+  let migrationAssistant: SPAPIMigrationAssistantTool;
+
+  beforeEach(() => {
+    migrationAssistant = new SPAPIMigrationAssistantTool(resourcesDir);
+  });
+
+  describe("outbound fulfillment migration", () => {
+    it("should return error for unsupported migration path", async () => {
+      const result = await migrationAssistant.migrationAssistant({
+        source_version: "fulfillment-outbound-v1",
+        target_version: "fulfillment-outbound-v2",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Unsupported migration path");
+      expect(result.content[0].text).toContain(
+        "fulfillment-outbound-v2020-07-01",
+      );
+    });
+
+    it("should return general guidance when no source code provided", async () => {
+      const result = await migrationAssistant.migrationAssistant({
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain(
+        "Fulfillment Outbound API Migration Guide",
+      );
+      expect(result.content[0].text).toContain("v2020-07-01 → v2025-09-24");
+      expect(result.content[0].text).toContain("API Method Mapping");
+      expect(result.content[0].text).toContain(
+        "Delivery Service Level Mappings",
+      );
+      expect(result.content[0].text).toContain("Request Body Changes");
+    });
+
+    it("should include key changes in general guidance", async () => {
+      const result = await migrationAssistant.migrationAssistant({
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      const text = result.content[0].text;
+      // Base path change
+      expect(text).toContain("/fba/outbound/2020-07-01");
+      expect(text).toContain("/fulfillment/outbound/2025-09-24");
+      // New header
+      expect(text).toContain("x-amzn-fulfillment-service-id");
+      // Operation renames
+      expect(text).toContain("createOrder");
+      expect(text).toContain("getOrder");
+      expect(text).toContain("listOrders");
+      expect(text).toContain("getOrderPreview");
+    });
+
+    it("should include migration benefits in general guidance", async () => {
+      const result = await migrationAssistant.migrationAssistant({
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.content[0].text).toContain("Migration Benefits");
+      expect(result.content[0].text).toContain("Multi-tenant support");
+    });
+
+    it("should include tenancy operations in general guidance", async () => {
+      const result = await migrationAssistant.migrationAssistant({
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.content[0].text).toContain("Tenancy Operations");
+      expect(result.content[0].text).toContain("createFulfillmentService");
+      expect(result.content[0].text).toContain("listFulfillmentServices");
+    });
+
+    it("should include notification info in general guidance", async () => {
+      const result = await migrationAssistant.migrationAssistant({
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.content[0].text).toContain("Notifications");
+      expect(result.content[0].text).toContain("ORDER_STATUS_CHANGED");
+      expect(result.content[0].text).toContain("SHIPMENT_STATUS_CHANGED");
+      expect(result.content[0].text).toContain(
+        "SHIPMENT_PACKAGE_STATUS_CHANGED",
+      );
+    });
+
+    it("should include code examples in general guidance", async () => {
+      const result = await migrationAssistant.migrationAssistant({
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.content[0].text).toContain("Code Examples");
+      expect(result.content[0].text).toContain("createFulfillmentOrder");
+      expect(result.content[0].text).toContain("Webhook Subscription");
+    });
+
+    it("should analyze code when source code provided", async () => {
+      const sourceCode = `
+        const response = await createFulfillmentOrder({
+          sellerFulfillmentOrderId: 'ORDER-123',
+          shippingSpeedCategory: 'Standard',
+          fulfillmentAction: 'Ship',
+          fulfillmentPolicy: 'FillAllAvailable',
+          destinationAddress: { name: 'John Doe' },
+          items: [{ sellerSKU: 'SKU-001', quantity: 2 }],
+          marketplaceId: 'ATVPDKIKX0DER'
+        });
+      `;
+
+      const result = await migrationAssistant.migrationAssistant({
+        source_code: sourceCode,
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain("Migration Analysis");
+      expect(result.content[0].text).toContain("Refactored Code");
+    });
+
+    it("should return analysis only when analysis_only is true", async () => {
+      const sourceCode = `
+        const response = await createFulfillmentOrder({
+          sellerFulfillmentOrderId: 'ORDER-123',
+          shippingSpeedCategory: 'Standard'
+        });
+      `;
+
+      const result = await migrationAssistant.migrationAssistant({
+        source_code: sourceCode,
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+        analysis_only: true,
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain("Analysis Report");
+      expect(result.content[0].text).not.toContain("Refactored Code");
+    });
+
+    it("should detect deprecated API methods", async () => {
+      const sourceCode = `
+        const features = await getFeatures(marketplaceId);
+        const inventory = await getFeatureInventory(marketplaceId, featureName);
+        const tracking = await getPackageTrackingDetails(packageNumber);
+        const returnResult = await createFulfillmentReturn(orderId, items);
+        const reasonCodes = await listReturnReasonCodes(sellerSku);
+      `;
+
+      const result = await migrationAssistant.migrationAssistant({
+        source_code: sourceCode,
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain("getFeatures");
+      expect(result.content[0].text).toContain("getFeatureInventory");
+      expect(result.content[0].text).toContain("getPackageTrackingDetails");
+      expect(result.content[0].text).toContain("createFulfillmentReturn");
+      expect(result.content[0].text).toContain("listReturnReasonCodes");
+      expect(result.content[0].text).toContain("Deprecated");
+    });
+
+    it("should detect delivery service level values", async () => {
+      const sourceCode = `
+        const order = await createFulfillmentOrder({
+          shippingSpeedCategory: 'Standard',
+          items: [{ sellerSKU: 'SKU-001' }]
+        });
+
+        if (preview.shippingSpeedCategory === 'Expedited') {
+          // handle expedited
+        }
+      `;
+
+      const result = await migrationAssistant.migrationAssistant({
+        source_code: sourceCode,
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain("Delivery Service Level");
+      expect(result.content[0].text).toContain("STANDARD");
+      expect(result.content[0].text).toContain("EXPEDITED");
+    });
+
+    it("should detect fulfillment action and policy values", async () => {
+      const sourceCode = `
+        const order = await createFulfillmentOrder({
+          fulfillmentAction: 'Ship',
+          fulfillmentPolicy: 'FillAllAvailable'
+        });
+      `;
+
+      const result = await migrationAssistant.migrationAssistant({
+        source_code: sourceCode,
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain("SHIP");
+      expect(result.content[0].text).toContain("FILL_ALL_AVAILABLE");
+    });
+
+    it("should detect fulfillment order status values", async () => {
+      const sourceCode = `
+        const order = await getFulfillmentOrder(orderId);
+        if (order.fulfillmentOrderStatus === 'Complete') {
+          // handle complete
+        } else if (order.fulfillmentOrderStatus === 'Processing') {
+          // handle processing
+        }
+      `;
+
+      const result = await migrationAssistant.migrationAssistant({
+        source_code: sourceCode,
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain("Status Value");
+      expect(result.content[0].text).toContain("COMPLETE");
+      expect(result.content[0].text).toContain("PROCESSING");
+    });
+
+    it("should detect payload wrapper usage", async () => {
+      const sourceCode = `
+        const response = await getFulfillmentOrder(orderId);
+        const order = response.payload.fulfillmentOrder;
+        const items = response.payload.fulfillmentOrderItems;
+      `;
+
+      const result = await migrationAssistant.migrationAssistant({
+        source_code: sourceCode,
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain("payload wrapper");
+    });
+
+    it("should detect base path usage", async () => {
+      const sourceCode = `
+        const url = '/fba/outbound/2020-07-01/fulfillmentOrders';
+        const response = await fetch(baseUrl + url);
+      `;
+
+      const result = await migrationAssistant.migrationAssistant({
+        source_code: sourceCode,
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain("Base path changed");
+      expect(result.content[0].text).toContain(
+        "/fulfillment/outbound/2025-09-24",
+      );
+    });
+
+    it("should detect attribute mappings", async () => {
+      const sourceCode = `
+        const orderId = order.sellerFulfillmentOrderId;
+        const status = order.fulfillmentOrderStatus;
+        const speed = order.shippingSpeedCategory;
+        const shipments = order.fulfillmentShipments;
+      `;
+
+      const result = await migrationAssistant.migrationAssistant({
+        source_code: sourceCode,
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain("Attribute Mappings");
+      expect(result.content[0].text).toContain("orderId");
+      expect(result.content[0].text).toContain("status");
+      expect(result.content[0].text).toContain("deliveryServiceLevel");
+    });
+
+    it("should handle source_files input", async () => {
+      const sourceFiles = [
+        {
+          fileName: "fulfillment-service.ts",
+          code: `
+            const response = await createFulfillmentOrder({
+              sellerFulfillmentOrderId: 'ORDER-123',
+              shippingSpeedCategory: 'Standard'
+            });
+          `,
+        },
+        {
+          fileName: "preview-service.ts",
+          code: `
+            const preview = await getFulfillmentPreview({
+              shippingSpeedCategories: ['Standard', 'Expedited']
+            });
+          `,
+        },
+      ];
+
+      const result = await migrationAssistant.migrationAssistant({
+        source_files: sourceFiles,
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain("fulfillment-service.ts");
+      expect(result.content[0].text).toContain("preview-service.ts");
+    });
+
+    it("should skip files with no migration-relevant findings", async () => {
+      const sourceFiles = [
+        {
+          fileName: "unrelated-service.ts",
+          code: `
+            function calculateTotal(products) {
+              return products.reduce((sum, product) => sum + product.price, 0);
+            }
+          `,
+        },
+      ];
+
+      const result = await migrationAssistant.migrationAssistant({
+        source_files: sourceFiles,
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain(
+        "No Fulfillment Outbound API v2020-07-01 usage detected",
+      );
+    });
+
+    it("should detect query parameter usage", async () => {
+      const sourceCode = `
+        const orders = await listAllFulfillmentOrders({
+          queryStartDate: '2025-01-01T00:00:00Z',
+          nextToken: savedToken
+        });
+      `;
+
+      const result = await migrationAssistant.migrationAssistant({
+        source_code: sourceCode,
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain("Query Parameter");
+    });
+
+    it("should generate refactored code with renamed API methods", async () => {
+      const sourceCode = `
+        const order = await createFulfillmentOrder(params);
+        const details = await getFulfillmentOrder(orderId);
+        const list = await listAllFulfillmentOrders({ queryStartDate: date });
+        const preview = await getFulfillmentPreview(previewParams);
+      `;
+
+      const result = await migrationAssistant.migrationAssistant({
+        source_code: sourceCode,
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.isError).toBeUndefined();
+      const text = result.content[0].text;
+      expect(text).toContain("createOrder");
+      expect(text).toContain("getOrder");
+      expect(text).toContain("listOrders");
+      expect(text).toContain("getOrderPreview");
+    });
+
+    it("should include migration checklist in report", async () => {
+      const sourceCode = `
+        const order = await createFulfillmentOrder({
+          sellerFulfillmentOrderId: 'ORDER-123'
+        });
+      `;
+
+      const result = await migrationAssistant.migrationAssistant({
+        source_code: sourceCode,
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain("Migration Checklist");
+      expect(result.content[0].text).toContain("Testing Recommendations");
+    });
+
+    it("should detect getFulfillmentPreview with response structure changes", async () => {
+      const sourceCode = `
+        const result = await getFulfillmentPreview({
+          address: { name: 'John', addressLine1: '123 Main St' },
+          items: [{ sellerSku: 'SKU-001', quantity: 1 }],
+          shippingSpeedCategories: ['Standard', 'Expedited']
+        });
+
+        const previews = result.payload.fulfillmentPreviews;
+        previews.forEach(preview => {
+          const shipments = preview.fulfillmentPreviewShipments;
+          const arrival = shipments[0].earliestArrivalDate;
+        });
+      `;
+
+      const result = await migrationAssistant.migrationAssistant({
+        source_code: sourceCode,
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.isError).toBeUndefined();
+      const text = result.content[0].text;
+      expect(text).toContain("getFulfillmentPreview");
+      expect(text).toContain("payload wrapper");
+      expect(text).toContain("plannedShipments");
+      expect(text).toContain("offers");
+    });
+  });
+});

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/tests/tools/outbound-fulfillment-migration-tools.test.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/tests/tools/outbound-fulfillment-migration-tools.test.ts
@@ -12,6 +12,18 @@ describe("SPAPIMigrationAssistantTool - Outbound Fulfillment", () => {
   });
 
   describe("outbound fulfillment migration", () => {
+    it("should prepend disclaimer to all outbound migration responses", async () => {
+      const result = await migrationAssistant.migrationAssistant({
+        source_version: "fulfillment-outbound-v2020-07-01",
+        target_version: "fulfillment-outbound-2025-09-24",
+      });
+
+      expect(result.content[0].text).toContain("⚠️ DISCLAIMER");
+      expect(result.content[0].text).toContain(
+        "has NOT been officially released yet and is subject to change",
+      );
+    });
+
     it("should return error for unsupported migration path", async () => {
       const result = await migrationAssistant.migrationAssistant({
         source_version: "fulfillment-outbound-v1",


### PR DESCRIPTION
Port the Fulfillment Outbound API v2020-07-01 -> v2025-09-24 migration feature into the sp-api-dev-assistant-mcp-server package.

- Adapt SPAPIMigrationAssistantTool constructor to accept a resources directory so it can load both Orders and Outbound migration data, while remaining backwards compatible with callers that passed a direct JSON path.
- Add outbound-fulfillment-migration module with migration-data, code-analyzer, code-generator, guidance-formatter, and report-formatter.
- Register Outbound migration data and v2025-09-24 swagger as MCP resources in index.ts, resolving paths via the dataRoot env-driven resources directory.
- Update migration schemas to document the new source/target version values.
- Add 22 tests for the outbound fulfillment migration paths covering general guidance, code analysis, refactored code generation, and source_files handling.

All 506 tests pass.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
