### PR TITLE
fix(search): upgrade vectra to ^0.14.0 in consolidation workflow

### DIFF
--- a/.github/workflows/consolidate-dev-mcp-server.yml
+++ b/.github/workflows/consolidate-dev-mcp-server.yml
@@ -155,7 +155,7 @@ jobs:
           if (!pkg.dependencies) pkg.dependencies = {};
           pkg.dependencies['@huggingface/transformers'] = '^3.0.0';
           pkg.dependencies['sharp'] = '^0.33.5';
-          pkg.dependencies['vectra'] = '^0.9.0';
+          pkg.dependencies['vectra'] = '^0.14.0';
 
           writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
           EOF


### PR DESCRIPTION
## Problem
sp_api_reference tool returns zero results for all queries.

## Root Cause
The consolidation workflow hardcodes vectra: ^0.9.0 in the published npm package, but vector-store.ts uses vectra 0.14's 4-param queryItems(vector, query, topK, filter) signature. With vectra 0.9 (3-param), the empty string "" gets interpreted as topK (coerced to 0), so zero results are returned.

## Fix
One-line change: '^0.9.0' → '^0.14.0' in .github/workflows/consolidate-dev-mcp-server.yml.