### PR TITLE
Getting the amazon selling partner MCP working on Claude desktop for windows via index.ts update

### DIFF
--- a/use-cases/sp-api-dev-mcp/src/index.ts
+++ b/use-cases/sp-api-dev-mcp/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import { dirname, join } from "path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -26,4 +26,4 @@ if (!serverName || !SERVER_MAP[serverName]) {
 }
 
 const serverFile = join(bundledDir, SERVER_MAP[serverName]);
-await import(serverFile);
+await import(pathToFileURL(serverFile).href);


### PR DESCRIPTION
ts update provides cross platform compatibility.

*Issue #, if available:*
Current build throws an ERR_UNSUPPORTED_ESM_URL_SCHEME on Claude for windows desktop, verified across multiple installs. 

*Description of changes:*
https://gist.github.com/ben-pierre/2e9df8ceb9f953c7db70b476bd5f6204

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
