### PR TITLE
Fix memory and performance issues in sp-api-dev-mcp reference tool indexing

### DIFF
--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/scripts/search-tools/build-index.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/scripts/search-tools/build-index.ts
@@ -60,15 +60,21 @@ async function buildIndex() {
 
     const chunks = indexManager.chunkText(cleanText, 256, 50);
 
+    const pending: Array<{ chunkIndex: number; text: string }> = [];
     for (let i = 0; i < chunks.length; i++) {
       if (chunks[i].length < 100) continue;
 
-      const chunkText = `${doc.title}: ${chunks[i]}`;
-      const vector = await embeddingService.embedDocument(chunkText);
+      pending.push({ chunkIndex: i, text: `${doc.title}: ${chunks[i]}` });
+    }
 
+    const vectors = await embeddingService.embedDocumentBatch(
+      pending.map((chunk) => chunk.text),
+    );
+
+    for (let i = 0; i < pending.length; i++) {
       const item: VectorStoreItem = {
-        id: `${doc.url}#chunk-${i}`,
-        text: chunkText,
+        id: `${doc.url}#chunk-${pending[i].chunkIndex}`,
+        text: pending[i].text,
         metadata: {
           title: doc.title,
           sourceUrl: doc.url,
@@ -76,11 +82,11 @@ async function buildIndex() {
           category: doc.category,
           locale: doc.locale,
           lastUpdated: doc.lastUpdated,
-          chunkIndex: i,
+          chunkIndex: pending[i].chunkIndex,
         },
       };
 
-      await vectorStore.upsert(item, vector);
+      await vectorStore.upsert(item, vectors[i]);
       totalChunks++;
     }
   }

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/scripts/search-tools/build-index.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/scripts/search-tools/build-index.ts
@@ -47,16 +47,14 @@ async function buildIndex() {
   );
 
   const crawler = new SPAPIDocsCrawler(cacheDir);
-  console.log("Crawling SP-API docs (en-US)...");
-  const documents = await crawler.crawl();
-  console.log(`Crawled ${documents.length} pages.`);
-
-  console.log("Processing and embedding...");
+  console.log("Crawling, processing and embedding SP-API docs (en-US)...");
   let totalChunks = 0;
+  let documentsCrawled = 0;
 
   await vectorStore.beginUpdate();
 
-  for (const doc of documents) {
+  for await (const doc of crawler.crawl()) {
+    documentsCrawled++;
     const cleanText = indexManager.stripHtml(doc.htmlContent);
     if (!cleanText) continue;
 
@@ -89,6 +87,8 @@ async function buildIndex() {
 
   await vectorStore.endUpdate();
 
+  console.log(`Crawled ${documentsCrawled} pages.`);
+
   // Write metadata
   const metadata: IndexMetadata = {
     lastSuccessfulIndex: new Date().toISOString(),
@@ -97,7 +97,7 @@ async function buildIndex() {
       {
         source: "sp-api-docs",
         timestamp: new Date().toISOString(),
-        documentsCrawled: documents.length,
+        documentsCrawled,
       },
     ],
   };

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/scripts/search-tools/build-index.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/scripts/search-tools/build-index.ts
@@ -54,6 +54,8 @@ async function buildIndex() {
   console.log("Processing and embedding...");
   let totalChunks = 0;
 
+  await vectorStore.beginUpdate();
+
   for (const doc of documents) {
     const cleanText = indexManager.stripHtml(doc.htmlContent);
     if (!cleanText) continue;
@@ -84,6 +86,8 @@ async function buildIndex() {
       totalChunks++;
     }
   }
+
+  await vectorStore.endUpdate();
 
   // Write metadata
   const metadata: IndexMetadata = {

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/index.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/index.ts
@@ -284,6 +284,11 @@ OUTPUT CHAINING:
   async run(): Promise<void> {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
+
+    process.stdin.on("close", () => process.exit(0));
+    process.on("SIGTERM", () => process.exit(0));
+    process.on("SIGINT", () => process.exit(0));
+
     // Pre-load embedding model and initialize search index (non-blocking background tasks)
     this.search.embeddingService.preload().catch(() => {});
     this.search.indexManager.initialize().catch(() => {});

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/search-tools/crawlers/crawler-interface.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/search-tools/crawlers/crawler-interface.ts
@@ -4,8 +4,8 @@ export interface Crawler {
   /** Unique name for this crawler (e.g., 'sp-api-docs') */
   readonly name: string;
 
-  /** Crawl the data source and return raw documents */
-  crawl(): Promise<RawDocument[]>;
+  /** Crawl the data source, yielding raw documents one at a time */
+  crawl(): AsyncIterable<RawDocument>;
 
   /** Get metadata about this crawler's source */
   getSourceMetadata(): {

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/search-tools/crawlers/sp-api-docs-crawler.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/search-tools/crawlers/sp-api-docs-crawler.ts
@@ -26,20 +26,16 @@ export class SPAPIDocsCrawler implements Crawler {
     };
   }
 
-  async crawl(): Promise<RawDocument[]> {
-    const documents: RawDocument[] = [];
-
+  async *crawl(): AsyncGenerator<RawDocument> {
     const pages = await this.discoverPages();
     for (const url of pages) {
       try {
         const doc = await this.fetchAndParsePage(url);
-        if (doc) documents.push(doc);
+        if (doc) yield doc;
       } catch (error) {
         logger.error(`Failed to fetch ${url}: ${error}`);
       }
     }
-
-    return documents;
   }
 
   private async discoverPages(): Promise<string[]> {

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/search-tools/embedding-service.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/search-tools/embedding-service.ts
@@ -5,12 +5,18 @@
 
 import { pipeline as createPipeline } from "@huggingface/transformers";
 
+/** Documents embedded per forward pass by embedDocumentBatch(). */
+const EMBED_BATCH_SIZE = 32;
+
 export interface EmbeddingService {
   /** Generate a 384-dimension embedding vector for the given text (query prefix). */
   embed(text: string): Promise<number[]>;
 
   /** Generate a 384-dimension embedding vector for a document (passage prefix). */
   embedDocument(text: string): Promise<number[]>;
+
+  /** Generate 384-dimension embedding vectors for several documents at once. */
+  embedDocumentBatch(texts: string[]): Promise<number[][]>;
 
   /** Check if the model is loaded and ready. */
   isReady(): boolean;
@@ -52,6 +58,31 @@ export class TransformersEmbeddingService implements EmbeddingService {
       normalize: true,
     });
     return Array.from(output.data) as number[];
+  }
+
+  /**
+   * Embed several documents per forward pass instead of one at a time.
+   * Vectors are returned in the same order as the supplied texts.
+   */
+  async embedDocumentBatch(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+    await this.ensureModel();
+
+    const vectors: number[][] = [];
+    for (let i = 0; i < texts.length; i += EMBED_BATCH_SIZE) {
+      const batch = texts.slice(i, i + EMBED_BATCH_SIZE);
+      const output = await this.pipeline!(
+        batch.map((text) => `passage: ${text}`),
+        { pooling: "mean", normalize: true },
+      );
+      const [rows, dims] = output.dims;
+      for (let row = 0; row < rows; row++) {
+        vectors.push(
+          Array.from(output.data.slice(row * dims, (row + 1) * dims)) as number[],
+        );
+      }
+    }
+    return vectors;
   }
 
   /** Returns true if the model pipeline has been loaded into memory. */

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/search-tools/index-manager.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/search-tools/index-manager.ts
@@ -199,18 +199,23 @@ export class IndexManager {
             this.config.chunkOverlapTokens,
           );
 
+          const pending: Array<{ chunkIndex: number; text: string }> = [];
           for (let i = 0; i < chunks.length; i++) {
             // Skip chunks that are too short to be meaningful
             if (chunks[i].length < 100) continue;
 
             // Prepend page title to each chunk for better topic context in embeddings
-            const chunkText = `${doc.title}: ${chunks[i]}`;
-            const chunkId = `${doc.url}#chunk-${i}`;
-            const vector = await this.embeddingService.embedDocument(chunkText);
+            pending.push({ chunkIndex: i, text: `${doc.title}: ${chunks[i]}` });
+          }
 
+          const vectors = await this.embeddingService.embedDocumentBatch(
+            pending.map((chunk) => chunk.text),
+          );
+
+          for (let i = 0; i < pending.length; i++) {
             const item: VectorStoreItem = {
-              id: chunkId,
-              text: chunkText,
+              id: `${doc.url}#chunk-${pending[i].chunkIndex}`,
+              text: pending[i].text,
               metadata: {
                 title: doc.title,
                 sourceUrl: doc.url,
@@ -218,11 +223,11 @@ export class IndexManager {
                 category: doc.category,
                 locale: doc.locale,
                 lastUpdated: doc.lastUpdated,
-                chunkIndex: i,
+                chunkIndex: pending[i].chunkIndex,
               },
             };
 
-            await stagingStore.upsert(item, vector);
+            await stagingStore.upsert(item, vectors[i]);
             totalChunks++;
           }
         }

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/search-tools/index-manager.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/search-tools/index-manager.ts
@@ -129,6 +129,8 @@ export class IndexManager {
     let totalChunks = 0;
     const crawlHistory: IndexMetadata["crawlHistory"] = [];
 
+    await stagingStore.beginUpdate();
+
     for (const [name, crawler] of this.crawlers) {
       try {
         const documents = await crawler.crawl();
@@ -181,6 +183,7 @@ export class IndexManager {
           `Crawler ${name} failed, aborting reindex to preserve existing index`,
           error,
         );
+        await stagingStore.cancelUpdate();
         this.cleanStagingDir(stagingDir);
         if (attempt < 2) {
           logger.info("Retrying reindex in case of transient failure...");
@@ -192,6 +195,7 @@ export class IndexManager {
 
     if (totalChunks === 0) {
       logger.error("No chunks produced. Keeping existing index. Aborting");
+      await stagingStore.cancelUpdate();
       this.cleanStagingDir(stagingDir);
       if (attempt < 2) {
         logger.info("Retrying reindex after zero chunks...");
@@ -199,6 +203,8 @@ export class IndexManager {
       }
       return;
     }
+
+    await stagingStore.endUpdate();
 
     // Atomic swap: rename current → old, staging → current, delete old
     try {

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/search-tools/index-manager.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/search-tools/index-manager.ts
@@ -6,6 +6,7 @@ import {
   cpSync,
   rmSync,
   renameSync,
+  statSync,
 } from "fs";
 import { join } from "path";
 import * as cheerio from "cheerio";
@@ -19,6 +20,9 @@ import { VectraVectorStore } from "./vector-store.js";
 import type { EmbeddingService } from "./embedding-service.js";
 import type { Crawler } from "./crawlers/crawler-interface.js";
 import { logger } from "../../utils/logger.js";
+
+/** A reindex lock older than this is treated as abandoned by a dead process. */
+const REINDEX_LOCK_STALE_MS = 60 * 60 * 1000;
 
 /**
  * Orchestrates the full indexing lifecycle: pre-built index loading,
@@ -107,12 +111,61 @@ export class IndexManager {
       logger.info("Reindex already in progress, skipping");
       return;
     }
+    if (!this.acquireReindexLock()) {
+      logger.info("Reindex already running in another process, skipping");
+      return;
+    }
     this.reindexing = true;
 
     try {
       await this.doReindex(attempt);
     } finally {
       this.reindexing = false;
+      this.releaseReindexLock();
+    }
+  }
+
+  private get reindexLockPath(): string {
+    return join(this.config.dataDir, "reindex.lock");
+  }
+
+  /**
+   * Claim the right to reindex, across processes sharing this data directory.
+   * A lock left behind by a process that died is taken over once it goes stale.
+   */
+  private acquireReindexLock(): boolean {
+    const lockPath = this.reindexLockPath;
+    const contents = JSON.stringify({
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+    });
+
+    if (!existsSync(this.config.dataDir)) {
+      mkdirSync(this.config.dataDir, { recursive: true });
+    }
+
+    try {
+      writeFileSync(lockPath, contents, { flag: "wx" });
+      return true;
+    } catch {
+      try {
+        const age = Date.now() - statSync(lockPath).mtimeMs;
+        if (age < REINDEX_LOCK_STALE_MS) return false;
+        rmSync(lockPath, { force: true });
+        writeFileSync(lockPath, contents, { flag: "wx" });
+        logger.info("Took over a stale reindex lock");
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+
+  private releaseReindexLock(): void {
+    try {
+      rmSync(this.reindexLockPath, { force: true });
+    } catch (error) {
+      logger.warn("Failed to release reindex lock", error);
     }
   }
 

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/search-tools/index-manager.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/search-tools/index-manager.ts
@@ -133,9 +133,10 @@ export class IndexManager {
 
     for (const [name, crawler] of this.crawlers) {
       try {
-        const documents = await crawler.crawl();
+        let documentsCrawled = 0;
 
-        for (const doc of documents) {
+        for await (const doc of crawler.crawl()) {
+          documentsCrawled++;
           const cleanText = this.stripHtml(doc.htmlContent);
           if (!cleanText) continue;
 
@@ -176,7 +177,7 @@ export class IndexManager {
         crawlHistory.push({
           source: name,
           timestamp: new Date().toISOString(),
-          documentsCrawled: documents.length,
+          documentsCrawled,
         });
       } catch (error) {
         logger.error(

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/search-tools/vector-store.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/src/tools/search-tools/vector-store.ts
@@ -80,6 +80,21 @@ export class VectraVectorStore implements VectorStore {
     });
   }
 
+  async beginUpdate(): Promise<void> {
+    const index = await this.ensureIndex();
+    await index.beginUpdate();
+  }
+
+  async endUpdate(): Promise<void> {
+    const index = await this.ensureIndex();
+    await index.endUpdate();
+  }
+
+  async cancelUpdate(): Promise<void> {
+    const index = await this.ensureIndex();
+    index.cancelUpdate();
+  }
+
   async clear(): Promise<void> {
     const index = await this.ensureIndex();
     const items = await index.listItems();

--- a/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/tests/tools/search-tools.test.ts
+++ b/use-cases/sp-api-dev-mcp/sp-api-dev-assistant-mcp-server/tests/tools/search-tools.test.ts
@@ -742,7 +742,7 @@ describe("IndexManager lifecycle", () => {
     const manager = createManager();
     const mockCrawler = {
       name: "test-crawler",
-      crawl: async () => [],
+      crawl: async function* () {},
       getSourceMetadata: () => ({
         name: "test",
         baseUrl: "https://test.com",


### PR DESCRIPTION
## Summary

Fixes #461. The reported symptom (multi-GB MCP processes, host exhaustion) was real and
reproducible. The root causes were not the ones in the issue — see below.

Five targeted fixes, all additive:

| commit | fix |
|---|---|
| `1e6e416a` | Batch vectra writes — one commit per reindex instead of a full file rewrite per chunk |
| `be5ba882` | Stream crawled documents instead of buffering all 467 pages in memory |
| `49d10bb0` | Cross-process lock so N instances perform one reindex, not N |
| `93f3a1bc` | Embed chunks in batches instead of one at a time |
| `b97deffc` | Exit when the client disconnects, so orphaned servers can't accumulate |

## Measured

Three concurrent instances were deployed.
Verified end-to-end against the bundled artifact:
- fresh install serves the prebuilt index with no reindex
-  aged install crawls once under the lock
- queries return correctly

## Not addressed

Peak RSS during indexing is unchanged at ~2.4 GB. It's the fp32 `multilingual-e5-small`
model plus pipeline floor, it settles back to ~30 MB afterwards, and it is not a leak.
A smaller model can be used in the future to further optimize.

## On the issue's diagnosis

- **"Large API responses cached and never released"** — no such cache exists; `ExecuteApiTool`
  retains nothing.
- **"Lazy-load the embedding model"** — wouldn't have helped; the spike is not model load.
- **`vectra ^0.9.0`** — it's `^0.14.0`.
- **"Old instances not reclaimed"** — correct, and it was ours, not the client's. Nothing
  detected client disconnect and an uncleared 30-min timer kept the event loop alive forever.
  Two real orphans (1d 10h and 9h old) were found on a dev machine during this work.
- **"Single-instance guard"** — not implementable for stdio MCP (one process per client
  entry by design). The lock addresses the cost instead.
- **"opt_in'**: Left out of the scope of this PR.
