### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like how you provide a range of sample code for developers to learn about and use the Amazon Selling Partner API. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [LOW] Repo ships Claude Agent SDK code without an agent-guidance doc (AGENTS.md/CLAUDE.md)
   In , there is no document describing how to interact with the Claude Agent.  A clear agent-guidance document helps developers understand the available functionalities and best practices for using the agent, leading to more predictable and reliable runtime behavior.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)