### PR TITLE
Add MCF Fulfillment Outbound v2026-07-04 Java code recipes

### DIFF
--- a/code-recipes/java/src/main/java/multichannel_fulfillment/fulfillment_outbound_v2/McfConstants.java
+++ b/code-recipes/java/src/main/java/multichannel_fulfillment/fulfillment_outbound_v2/McfConstants.java
@@ -1,0 +1,236 @@
+package multichannel_fulfillment.fulfillment_outbound_v2;
+
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.Address;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.AdditionalServices;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.Amount;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.CreateOrderLineItem;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.CreateOrderRequest;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.GetOffersRequest;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.GetOrderPreviewRequest;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.Money;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.OfferDestination;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.OfferFulfillmentConfiguration;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.OfferItem;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.OrderDestination;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.OrderFulfillmentConfiguration;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.OrderOrigin;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.OrderProduct;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.OrderServices;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.PackagingService;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.PreviewDestination;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.PreviewFulfillmentConfiguration;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.PreviewLineItem;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.PreviewPackagingService;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.PreviewProduct;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.PreviewServiceLevel;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.PreviewServices;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.ProductIdentifier;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.ServiceLevel;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.UpdateOrderFulfillmentConfiguration;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.UpdateOrderRequest;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.VariablePrecisionAddress;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * Sample payloads for the MCF (Multichannel Fulfillment) Fulfillment Outbound (v2026-07-04) order-processing recipes.
+ *
+ * <p>These are realistic, US-focused sample payloads for the outbound API workflows. When adapting them for your own application, replace the placeholder
+ * values marked with angle brackets (e.g., &lt;recipient-name&gt;) with real data.</p>
+ *
+ * <p><b>What changed from the legacy version (v2020-07-01) to the new version (2026-07-04):</b></p>
+ * <ul>
+ *   <li>{@code sellerFulfillmentOrderId}          &rarr; {@code orderId}</li>
+ *   <li>{@code destinationAddress}                &rarr; {@code destination.deliveryAddress}</li>
+ *   <li>{@code marketplaceId}                     &rarr; {@code origin.countryCode}</li>
+ *   <li>{@code items}                             &rarr; {@code lineItems}</li>
+ *   <li>item {@code sellerSku}                    &rarr; {@code product.productIdentifier.amazonSku}</li>
+ *   <li>item {@code sellerFulfillmentOrderItemId} &rarr; {@code lineItemId}</li>
+ *   <li>item {@code quantity: 2}                  &rarr; {@code amount: {unit: "EACHES", value: "2.0"}}</li>
+ *   <li>{@code shippingSpeedCategory: "Standard"} &rarr; {@code fulfillmentConfiguration.serviceLevel.serviceTiers: ["STANDARD"]}</li>
+ *   <li>{@code fulfillmentAction: "Ship"/"Hold"}  &rarr; {@code fulfillmentConfiguration.action: "SHIP"/"HOLD"}</li>
+ *   <li>{@code fulfillmentPolicy: "FillAllAvailable"} &rarr; {@code fulfillmentConfiguration.policy: "FILL_ALL_AVAILABLE"}</li>
+ *   <li>{@code featureConstraints: [CHANNEL.X]}   &rarr; top-level {@code channel} field (e.g., "TIKTOK","WALMART","TEMU")</li>
+ *   <li>{@code featureConstraints: [BLANK_BOX]}   &rarr; {@code fulfillmentConfiguration.services.packaging}</li>
+ * </ul>
+ *
+ * <p><b>NOTE:</b> These samples cater to the US marketplace. Service tiers are limited to {@code STANDARD} and {@code EXPEDITED} ({@code PRIORITY} is CA/IN/MX only and
+ * {@code SCHEDULED} is JP only). Payment-on-delivery is India-only and is intentionally omitted here.</p>
+ */
+public class McfConstants {
+
+    public static final String SAMPLE_ORDER_ID = "MCF-V2-TEST-ORDER-001";  // Your unique order ID
+
+    // listOrders query parameter — returns orders updated after this time (ISO 8601).
+    public static final String SAMPLE_LIST_ORDERS_UPDATED_AFTER = "2026-01-01T00:00:00Z";
+
+    // =========================================================================
+    // Sample payloads for RECIPE 1 — Product Page & Checkout Previews
+    // =========================================================================
+
+    /**
+     * Build a sample getOffers request body.
+     *
+     * <p>Lightweight, item-level "delivery promise" for the product/cart page. Works with a variable-precision address (postal code + country is enough) or an IP
+     * address. Returns per-item delivery date ranges with an expiry — no fees.</p>
+     */
+    public static GetOffersRequest sampleOffersRequest() {
+        // NOTE: OfferFulfillmentConfiguration.serviceLevel() takes a PreviewServiceLevel in this
+        // version (which exposes serviceTiers). OfferServiceLevel is a response-only shape.
+        PreviewServiceLevel serviceLevel = new PreviewServiceLevel()
+                .serviceTiers(Collections.singletonList("STANDARD"));  // US tiers: STANDARD, EXPEDITED
+
+        OfferFulfillmentConfiguration fulfillmentConfiguration = new OfferFulfillmentConfiguration()
+                .serviceLevel(serviceLevel);
+
+        // VariablePrecisionAddress: postalCode + countryCode is sufficient.
+        // Alternatively, geolocate the shopper by setting only an IP address on the destination
+        // via OfferDestination.ipAddress(...).
+        VariablePrecisionAddress deliveryAddress = new VariablePrecisionAddress()
+                .postalCode("<postal-code>")   // e.g., "98101"
+                .countryCode("US");
+
+        OfferDestination destination = new OfferDestination()
+                .deliveryAddress(deliveryAddress);
+
+        // Multiple SKUs supported in a single call (one offerResult per item).
+        OfferItem item1 = new OfferItem()
+                .productIdentifier(new ProductIdentifier().amazonSku("MY-SKU-001"));
+        OfferItem item2 = new OfferItem()
+                .productIdentifier(new ProductIdentifier().amazonSku("MY-SKU-002"));
+
+        return new GetOffersRequest()
+                .fulfillmentConfiguration(fulfillmentConfiguration)
+                .origin(new OrderOrigin().countryCode("US"))
+                .destination(destination)
+                .items(Arrays.asList(item1, item2));
+    }
+
+    /**
+     * Build a sample getOrderPreview request body.
+     *
+     * <p>Detailed, order-level preview for the checkout-review step. Requires a full delivery address. Returns planned shipments (how the order splits), estimated
+     * shipping weight, delivery/ship intervals, and estimated fees.</p>
+     */
+    public static GetOrderPreviewRequest samplePreviewRequest() {
+        PreviewServiceLevel serviceLevel = new PreviewServiceLevel()
+                .serviceTiers(Arrays.asList("STANDARD", "EXPEDITED"));
+
+        // Packaging option replaces the v1 BLANK_BOX feature constraint.
+        PreviewFulfillmentConfiguration fulfillmentConfiguration = new PreviewFulfillmentConfiguration()
+                .serviceLevel(serviceLevel)
+                .services(new PreviewServices()
+                        .packaging(new PreviewPackagingService().packagingOption("UNBRANDED")));
+
+        Address deliveryAddress = new Address()
+                .name("<recipient-name>")
+                .addressLine1("<address-line-1>")
+                .city("<city>")
+                .stateOrRegion("<state>")      // e.g., "WA"
+                .postalCode("<postal-code>")   // e.g., "98101"
+                .countryCode("US");
+
+        PreviewDestination destination = new PreviewDestination()
+                .deliveryAddress(deliveryAddress);
+
+        PreviewLineItem lineItem = new PreviewLineItem()
+                .product(new PreviewProduct()
+                        .productIdentifier(new ProductIdentifier().amazonSku("MY-SKU-001"))
+                        // Optional declared value per unit (customs/insurance).
+                        .perUnitDeclaredValue(new Money().currencyCode("USD").amount("10.00")))
+                .amount(new Amount().unit("EACHES").value("1"));
+
+        return new GetOrderPreviewRequest()
+                .fulfillmentConfiguration(fulfillmentConfiguration)
+                .origin(new OrderOrigin().countryCode("US"))
+                .destination(destination)
+                .lineItems(Collections.singletonList(lineItem))
+                // Set true to omit fee estimates (faster). Default false = include fees.
+                .excludeEstimatedFees(false);
+    }
+
+    // =========================================================================
+    // Sample payload for RECIPE 2 — Create & Track Order and RECIPE 3 — Create & Cancel Order
+    // =========================================================================
+
+    /**
+     * Build a sample createOrder request body (action = SHIP).
+     */
+    public static CreateOrderRequest sampleCreateOrderRequest() {
+        return baseCreateOrderRequest("SHIP");
+        // Optional multi-channel routing: set .channel("TIKTOK") for a marketplace order.
+        // The blockAMZL additional service is set in baseCreateOrderRequest (applies to SHIP and HOLD).
+    }
+
+    /**
+     * Build a sample createOrder request body with action = HOLD (not shipped yet).
+     * The order stays on hold until released via updateOrder with action = SHIP.
+     */
+    public static CreateOrderRequest sampleCreateOrderOnHoldRequest() {
+        return baseCreateOrderRequest("HOLD");
+    }
+
+    /**
+     * Shared builder for the create-order payload. {@code action} is "SHIP" or "HOLD".
+     */
+    private static CreateOrderRequest baseCreateOrderRequest(String action) {
+        ServiceLevel serviceLevel = new ServiceLevel()
+                .serviceTiers(Collections.singletonList("STANDARD"));
+
+        AdditionalServices additional = new AdditionalServices();
+        additional.put("blockAMZL", "REQUIRED");  // request Amazon block AMZL (Amazon Logistics) as the delivery carrier
+
+        OrderServices services = new OrderServices()
+                .packaging(new PackagingService().packagingOption("UNBRANDED"))
+                .additional(additional);
+
+        OrderFulfillmentConfiguration fulfillmentConfiguration = new OrderFulfillmentConfiguration()
+                .serviceLevel(serviceLevel)
+                .action(action)                 // SHIP = fulfill now; HOLD = do not ship until released
+                .policy("FILL_ALL_AVAILABLE")   // FILL_OR_KILL | FILL_ALL | FILL_ALL_AVAILABLE
+                .services(services);
+        // FILL_OR_KILL       - all-or-nothing; ideal when partial fulfillment isn't acceptable.
+        // FILL_ALL           - all fulfillable items ship; unfulfillable items stay open for the seller.
+        // FILL_ALL_AVAILABLE - all fulfillable items ship immediately; unfulfillable items are cancelled.
+
+        Address deliveryAddress = new Address()
+                .name("<recipient-name>")
+                .addressLine1("<address-line-1>")
+                .city("<city>")
+                .stateOrRegion("<state>")
+                .postalCode("<postal-code>")
+                .countryCode("US")
+                .email("<shopper-email>");   // optional; used for notifications
+        // Optional drop-off support (new in this version): destination.deliveryNotes("Leave at front desk");
+
+        OrderDestination destination = new OrderDestination()
+                .deliveryAddress(deliveryAddress);
+
+        CreateOrderLineItem lineItem = new CreateOrderLineItem()
+                .lineItemId("item-001")
+                .product(new OrderProduct()
+                        .productIdentifier(new ProductIdentifier().amazonSku("MY-SKU-001")))
+                .amount(new Amount().unit("EACHES").value("1"));
+
+        return new CreateOrderRequest()
+                .orderId(SAMPLE_ORDER_ID)       // Your unique order ID
+                .fulfillmentConfiguration(fulfillmentConfiguration)
+                .origin(new OrderOrigin().countryCode("US"))
+                .destination(destination)
+                .lineItems(Collections.singletonList(lineItem));
+    }
+
+    // =========================================================================
+    // Sample payload for RECIPE 4 — Create On-Hold Order, then Request Shipment
+    // =========================================================================
+
+    /**
+     * Build a sample updateOrder request body that releases a held order for shipment.
+     */
+    public static UpdateOrderRequest sampleUpdateOrderShipRequest() {
+        return new UpdateOrderRequest()
+                .fulfillmentConfiguration(new UpdateOrderFulfillmentConfiguration()
+                        .action("SHIP"));
+    }
+}

--- a/code-recipes/java/src/main/java/multichannel_fulfillment/fulfillment_outbound_v2/McfCreateAndCancelOrderRecipe.java
+++ b/code-recipes/java/src/main/java/multichannel_fulfillment/fulfillment_outbound_v2/McfCreateAndCancelOrderRecipe.java
@@ -1,0 +1,136 @@
+package multichannel_fulfillment.fulfillment_outbound_v2;
+
+import software.amazon.spapi.api.fulfillment.outbound.v2026_07_04.FulfillmentOrdersApi;
+import software.amazon.spapi.api.fulfillment.outbound.v2026_07_04.FulfillmentPreviewsApi;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.CancelOrderResponse;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.CreateOrderResponse;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.GetOrderPreviewResponse;
+import util.Constants;
+import util.Recipe;
+
+/**
+ * MCF (Fulfillment Outbound v2026-07-04) Create and Cancel Order Recipe
+ * =====================================================================
+ *
+ * <p>This recipe demonstrates creating an MCF order and then cancelling it before it is
+ * fulfilled:</p>
+ * <ol>
+ *   <li><b>getOrderPreview</b> — Preview how the order will ship and its estimated fees.</li>
+ *   <li><b>createOrder</b> — Submit the fulfillment order.</li>
+ *   <li><b>cancelOrder</b> — Request that Amazon stop attempting to fulfill the order.</li>
+ * </ol>
+ *
+ * <p><b>When does cancellation succeed?</b></p>
+ * <p>Cancellation is only possible while the order has not yet entered fulfillment
+ * processing. Once items are picked/packed/shipped, a cancel request may be rejected.
+ * cancelOrder returns HTTP 202 (Accepted) and is best-effort; to confirm the final
+ * outcome, call getOrder and check that {@code order.status} is {@code CANCELLED}.</p>
+ *
+ * <p><b>DEVELOPER NOTES — Adapting this recipe for production:</b></p>
+ * <ol>
+ *   <li>Remove the {@code .endpoint(Constants.BACKEND_URL)} call in the API builders.
+ *       The SDK will automatically route to the correct SP-API endpoint.</li>
+ *   <li>Replace the placeholder LWA credentials in the base {@code Recipe} class
+ *       with your real credentials, ideally loaded from environment variables.</li>
+ *   <li>Update the sample payloads in {@code McfConstants} with real SKUs and addresses.</li>
+ * </ol>
+ *
+ * <p>API version: Fulfillment Outbound v2026-07-04</p>
+ */
+public class McfCreateAndCancelOrderRecipe extends Recipe {
+
+    private final FulfillmentPreviewsApi fulfillmentPreviewsApi;
+    private final FulfillmentOrdersApi fulfillmentOrdersApi;
+
+    public McfCreateAndCancelOrderRecipe() {
+        // DEVELOPER NOTE: For production, remove .endpoint(Constants.BACKEND_URL)
+        this.fulfillmentPreviewsApi = new FulfillmentPreviewsApi.Builder()
+                .lwaAuthorizationCredentials(lwaCredentials)
+                .endpoint(Constants.BACKEND_URL)
+                .build();
+        this.fulfillmentOrdersApi = new FulfillmentOrdersApi.Builder()
+                .lwaAuthorizationCredentials(lwaCredentials)
+                .endpoint(Constants.BACKEND_URL)
+                .build();
+    }
+
+    @Override
+    protected void start() {
+        System.out.println("======================================================================");
+        System.out.println("MCF (v2026-07-04) Create and Cancel Order Recipe");
+        System.out.println("======================================================================");
+
+        // Step 1 – Preview how the order will ship + fees
+        getOrderPreview();
+
+        // Step 2 – Create the order
+        createOrder();
+        String orderId = McfConstants.SAMPLE_ORDER_ID;
+
+        // Step 3 – Cancel the order before fulfillment
+        cancelOrder(orderId);
+
+        System.out.println("\n======================================================================");
+        System.out.println("MCF create and cancel order workflow completed successfully.");
+        System.out.println("======================================================================");
+    }
+
+    // -- Step 1: Get Order Preview --------------------------------------------
+
+    /**
+     * Call getOrderPreview to preview shipment split, weight, and fees before committing.
+     */
+    private GetOrderPreviewResponse getOrderPreview() {
+        System.out.println("\n--- Step 1: Get Order Preview ---");
+        try {
+            // SDK 1.11.1: getOrderPreview(GetOrderPreviewRequest body, String xAmznFulfillmentServiceId)
+            GetOrderPreviewResponse response = fulfillmentPreviewsApi.getOrderPreview(
+                    McfConstants.samplePreviewRequest(), null);
+            System.out.println("Order preview retrieved successfully.");
+            return response;
+        } catch (Exception e) {
+            System.err.println("Error getting order preview: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    // -- Step 2: Create Order -------------------------------------------------
+
+    /**
+     * Call createOrder to submit the MCF order. A successful (200/202) response means
+     * the order was accepted; creation may complete asynchronously.
+     */
+    private CreateOrderResponse createOrder() {
+        System.out.println("\n--- Step 2: Create Order ---");
+        try {
+            // SDK 1.11.1: createOrder(CreateOrderRequest body, String xAmznFulfillmentServiceId)
+            CreateOrderResponse response = fulfillmentOrdersApi.createOrder(
+                    McfConstants.sampleCreateOrderRequest(), null);
+            System.out.println("Fulfillment order created: " + McfConstants.SAMPLE_ORDER_ID);
+            return response;
+        } catch (Exception e) {
+            System.err.println("Error creating order: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    // -- Step 3: Cancel Order -------------------------------------------------
+
+    /**
+     * Call cancelOrder to request Amazon stop fulfilling the order. Returns HTTP 202
+     * (Accepted). Cancellation is best-effort: it only succeeds if the order has not yet
+     * entered fulfillment. To verify, call getOrder and check {@code order.status == "CANCELLED"}.
+     */
+    private CancelOrderResponse cancelOrder(String orderId) {
+        System.out.println("\n--- Step 3: Cancel Order ---");
+        try {
+            // SDK 1.11.1: cancelOrder(String orderId, String xAmznFulfillmentServiceId)
+            CancelOrderResponse response = fulfillmentOrdersApi.cancelOrder(orderId, null);
+            System.out.println("Cancel request accepted for: " + orderId);
+            return response;
+        } catch (Exception e) {
+            System.err.println("Error cancelling order: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/code-recipes/java/src/main/java/multichannel_fulfillment/fulfillment_outbound_v2/McfCreateAndTrackOrderRecipe.java
+++ b/code-recipes/java/src/main/java/multichannel_fulfillment/fulfillment_outbound_v2/McfCreateAndTrackOrderRecipe.java
@@ -1,0 +1,236 @@
+package multichannel_fulfillment.fulfillment_outbound_v2;
+
+import software.amazon.spapi.api.fulfillment.outbound.v2026_07_04.FulfillmentOrdersApi;
+import software.amazon.spapi.api.fulfillment.outbound.v2026_07_04.FulfillmentPreviewsApi;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.CarrierTracking;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.CreateOrderResponse;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.FulfillmentOrder;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.GetOrderPreviewResponse;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.GetOrderResponse;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.ListOrdersResponse;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.ModelPackage;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.Shipment;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.Tracking;
+import util.Constants;
+import util.Recipe;
+
+import java.time.OffsetDateTime;
+
+/**
+ * MCF (Fulfillment Outbound v2026-07-04) Create and Track Order Recipe
+ * =====================================================================
+ *
+ * <p>This recipe demonstrates the standard "happy-path" MCF order flow:</p>
+ * <ol>
+ *   <li><b>getOrderPreview</b> – Confirm how the order will ship (planned shipments),
+ *       estimated shipping weight, delivery/ship windows, and estimated fees before committing.</li>
+ *   <li><b>createOrder</b> – Submit the fulfillment order so Amazon ships the items from FBA inventory to the customer.</li>
+ *   <li><b>listOrders</b> – Retrieve recently updated orders (reconciliation / confirming acceptance).</li>
+ *   <li><b>getOrder</b> – Retrieve the order to read its status and, once shipped, the per-package tracking details.</li>
+ * </ol>
+ *
+ * <p><b>How tracking works in this version of the API (important):</b></p>
+ * <p>There is no standalone {@code getPackageTrackingDetails} operation in this version.
+ * Package tracking is embedded in the getOrder response at
+ * {@code order.shipments[].packages[].tracking.{carrier, amazon, proofOfDelivery}}.
+ * Tracking values only populate once the order actually ships, so a freshly created
+ * order may not have tracking yet. For real-time, milestone-level tracking, refer to
+ * the Tracking API — it is a different API model and out of scope for this recipe.</p>
+ *
+ * <p><b>Real-world notes:</b></p>
+ * <ul>
+ *   <li>Steps 1 and 2 typically happen in quick succession at checkout.</li>
+ *   <li>Prefer subscribing to the FULFILLMENT_ORDER_STATUS notification over polling getOrder, especially because createOrder may complete asynchronously.</li>
+ * </ul>
+ *
+ * <p><b>DEVELOPER NOTES — Adapting this recipe for production:</b></p>
+ * <ol>
+ *   <li>Remove the {@code .endpoint(Constants.BACKEND_URL)} call in the API builders. The SDK will automatically route to the correct SP-API endpoint.</li>
+ *   <li>Replace the placeholder LWA credentials in the base {@code Recipe} class with your real credentials, ideally loaded from environment variables.</li>
+ *   <li>Update the sample payloads in {@code McfConstants} with real SKUs and addresses.</li>
+ * </ol>
+ *
+ * <p>API version: Fulfillment Outbound v2026-07-04</p>
+ */
+public class McfCreateAndTrackOrderRecipe extends Recipe {
+
+    private final FulfillmentPreviewsApi fulfillmentPreviewsApi;
+    private final FulfillmentOrdersApi fulfillmentOrdersApi;
+
+    public McfCreateAndTrackOrderRecipe() {
+        // DEVELOPER NOTE: For production, remove .endpoint(Constants.BACKEND_URL)
+        this.fulfillmentPreviewsApi = new FulfillmentPreviewsApi.Builder()
+                .lwaAuthorizationCredentials(lwaCredentials)
+                .endpoint(Constants.BACKEND_URL)
+                .build();
+        this.fulfillmentOrdersApi = new FulfillmentOrdersApi.Builder()
+                .lwaAuthorizationCredentials(lwaCredentials)
+                .endpoint(Constants.BACKEND_URL)
+                .build();
+    }
+
+    @Override
+    protected void start() {
+        System.out.println("======================================================================");
+        System.out.println("MCF (v2026-07-04) Create and Track Order Recipe");
+        System.out.println("======================================================================");
+
+        // Step 1 – Preview how the order will ship + fees
+        getOrderPreview();
+
+        // Step 2 – Create the order
+        createOrder();
+        String orderId = McfConstants.SAMPLE_ORDER_ID;
+
+        // Step 3 – List recent orders (reconciliation)
+        listOrders();
+
+        // Step 4 – Get order status and package tracking
+        GetOrderResponse order = getOrder(orderId);
+        printPackageTracking(order);
+
+        System.out.println("\n======================================================================");
+        System.out.println("MCF create and track order workflow completed successfully.");
+        System.out.println("======================================================================");
+    }
+
+    // -- Step 1: Get Order Preview --------------------------------------------
+
+    /**
+     * Call getOrderPreview to see how the order will ship, its estimated weight and
+     * delivery/ship windows, and the estimated fees before committing to createOrder.
+     */
+    private GetOrderPreviewResponse getOrderPreview() {
+        System.out.println("\n--- Step 1: Get Order Preview ---");
+        try {
+            // SDK 1.11.1: getOrderPreview(GetOrderPreviewRequest body, String xAmznFulfillmentServiceId)
+            GetOrderPreviewResponse response = fulfillmentPreviewsApi.getOrderPreview(
+                    McfConstants.samplePreviewRequest(), null);
+            System.out.println("Order preview retrieved successfully.");
+            return response;
+        } catch (Exception e) {
+            System.err.println("Error getting order preview: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    // -- Step 2: Create Order -------------------------------------------------
+
+    /**
+     * Call createOrder to submit the MCF order. A successful (200/202) response means
+     * the order was accepted; creation may complete asynchronously.
+     */
+    private CreateOrderResponse createOrder() {
+        System.out.println("\n--- Step 2: Create Order ---");
+        try {
+            // SDK 1.11.1: createOrder(CreateOrderRequest body, String xAmznFulfillmentServiceId)
+            CreateOrderResponse response = fulfillmentOrdersApi.createOrder(
+                    McfConstants.sampleCreateOrderRequest(), null);
+            System.out.println("Fulfillment order created: " + McfConstants.SAMPLE_ORDER_ID);
+            return response;
+        } catch (Exception e) {
+            System.err.println("Error creating order: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    // -- Step 3: List Orders --------------------------------------------------
+
+    /**
+     * Call listOrders to retrieve recently updated orders. Handy for reconciliation
+     * or confirming an order was accepted.
+     *
+     * <p>Query parameters: {@code updatedAfter} (OffsetDateTime), {@code shipments}
+     * ("INCLUDE" default / "EXCLUDE"), {@code pageToken} (from a prior
+     * response's pagination.nextToken).</p>
+     */
+    private ListOrdersResponse listOrders() {
+        System.out.println("\n--- Step 3: List Orders ---");
+        try {
+            OffsetDateTime updatedAfter =
+                    OffsetDateTime.parse(McfConstants.SAMPLE_LIST_ORDERS_UPDATED_AFTER);
+            // SDK 1.11.1: listOrders(String xAmznFulfillmentServiceId, OffsetDateTime updatedAfter,
+            //                        String pageToken, String shipments)
+            ListOrdersResponse response = fulfillmentOrdersApi.listOrders(
+                    null, updatedAfter, null, null);
+            System.out.println("Orders listed successfully.");
+            return response;
+        } catch (Exception e) {
+            System.err.println("Error listing orders: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    // -- Step 4: Get Order (status + package tracking) ------------------------
+
+    /**
+     * Call getOrder to check the order status and, once shipped, read the per-package
+     * tracking details.
+     *
+     * <p>Key fields in the response:</p>
+     * <ul>
+     *   <li>order.status (e.g., PROCESSING, COMPLETE, COMPLETE_PARTIAL, CANCELLED)</li>
+     *   <li>order.shipments[].status (PROCESSING, SHIPPED, CANCELLED)</li>
+     *   <li>order.shipments[].packages[].packageId</li>
+     *   <li>order.shipments[].packages[].status (PROCESSING, IN_TRANSIT, DELAYED,
+     *       OUT_FOR_DELIVERY, DELIVERED, UNDELIVERABLE, EXPIRED)</li>
+     *   <li>order.shipments[].packages[].tracking.carrier.{carrierCode, trackingNumber, trackingUrl}</li>
+     *   <li>order.shipments[].packages[].tracking.amazon.{trackingNumber, trackingUrl}</li>
+     * </ul>
+     */
+    private GetOrderResponse getOrder(String orderId) {
+        System.out.println("\n--- Step 4: Get Order ---");
+        try {
+            // SDK 1.11.1: getOrder(String orderId, String xAmznFulfillmentServiceId, String shipments)
+            GetOrderResponse response = fulfillmentOrdersApi.getOrder(orderId, null, null);
+            System.out.println("Order details retrieved for: " + orderId);
+            return response;
+        } catch (Exception e) {
+            System.err.println("Error getting order: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    // -- Helper: read embedded package tracking from the getOrder response ----
+
+    /**
+     * Walk order.shipments[].packages[].tracking and print carrier/Amazon tracking.
+     * In this version, there is no separate tracking call — tracking is embedded here and only
+     * populates once the order ships.
+     */
+    private void printPackageTracking(GetOrderResponse orderResponse) {
+        System.out.println("\n--- Package Tracking (from getOrder) ---");
+        if (orderResponse == null || orderResponse.getOrder() == null) {
+            System.out.println("No order payload returned.");
+            return;
+        }
+        FulfillmentOrder order = orderResponse.getOrder();
+        if (order.getShipments() == null || order.getShipments().isEmpty()) {
+            System.out.println("No shipments yet — order may still be processing.");
+            return;
+        }
+        boolean anyTracking = false;
+        for (Shipment shipment : order.getShipments()) {
+            if (shipment.getPackages() == null) {
+                continue;
+            }
+            for (ModelPackage pkg : shipment.getPackages()) {
+                Tracking tracking = pkg.getTracking();
+                if (tracking == null) {
+                    continue;
+                }
+                CarrierTracking carrier = tracking.getCarrier();
+                if (carrier != null) {
+                    anyTracking = true;
+                    System.out.println("  Package " + pkg.getPackageId()
+                            + " [" + pkg.getStatus() + "] via " + carrier.getCarrierCode()
+                            + " — tracking " + carrier.getTrackingNumber()
+                            + " (" + carrier.getTrackingUrl() + ")");
+                }
+            }
+        }
+        if (!anyTracking) {
+            System.out.println("No package tracking available yet — tracking populates once the order ships.");
+        }
+    }
+}

--- a/code-recipes/java/src/main/java/multichannel_fulfillment/fulfillment_outbound_v2/McfCreateOnHoldAndShipOrderRecipe.java
+++ b/code-recipes/java/src/main/java/multichannel_fulfillment/fulfillment_outbound_v2/McfCreateOnHoldAndShipOrderRecipe.java
@@ -1,0 +1,161 @@
+package multichannel_fulfillment.fulfillment_outbound_v2;
+
+import software.amazon.spapi.api.fulfillment.outbound.v2026_07_04.FulfillmentOrdersApi;
+import software.amazon.spapi.api.fulfillment.outbound.v2026_07_04.FulfillmentPreviewsApi;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.CreateOrderResponse;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.GetOrderPreviewResponse;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.GetOrderResponse;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.UpdateOrderResponse;
+import util.Constants;
+import util.Recipe;
+
+/**
+ * MCF (Fulfillment Outbound v2026-07-04) Create On-Hold and Ship Order Recipe
+ * ===========================================================================
+ *
+ * <p>This recipe demonstrates creating an MCF order that is placed on hold (not shipped
+ * immediately) and later released for shipment:</p>
+ * <ol>
+ *   <li><b>getOrderPreview</b> — Preview how the order will ship and its estimated fees.</li>
+ *   <li><b>createOrder</b> (action = HOLD) — Submit the order without shipping it.
+ *       The order is held until you explicitly release it.</li>
+ *   <li><b>updateOrder</b> (action = SHIP) — Release the held order for shipment.</li>
+ *   <li><b>getOrder</b> — Confirm the order moved out of hold and read its status / shipments.</li>
+ * </ol>
+ *
+ * <p><b>Why hold an order?</b></p>
+ * <p>Holding is useful when you want to reserve fulfillment but defer shipment — for
+ * example, to allow a cancellation window, batch releases, or wait on a payment or fraud
+ * check before the package leaves the fulfillment center. The order can be held for 14 days.</p>
+ *
+ * <p><b>DEVELOPER NOTES — Adapting this recipe for production:</b></p>
+ * <ol>
+ *   <li>Remove the {@code .endpoint(Constants.BACKEND_URL)} call in the API builders.
+ *       The SDK will automatically route to the correct SP-API endpoint.</li>
+ *   <li>Replace the placeholder LWA credentials in the base {@code Recipe} class
+ *       with your real credentials, ideally loaded from environment variables.</li>
+ *   <li>Update the sample payloads in {@code McfConstants} with real SKUs and addresses.</li>
+ * </ol>
+ *
+ * <p>API version: Fulfillment Outbound v2026-07-04</p>
+ */
+public class McfCreateOnHoldAndShipOrderRecipe extends Recipe {
+
+    private final FulfillmentPreviewsApi fulfillmentPreviewsApi;
+    private final FulfillmentOrdersApi fulfillmentOrdersApi;
+
+    public McfCreateOnHoldAndShipOrderRecipe() {
+        // DEVELOPER NOTE: For production, remove .endpoint(Constants.BACKEND_URL)
+        this.fulfillmentPreviewsApi = new FulfillmentPreviewsApi.Builder()
+                .lwaAuthorizationCredentials(lwaCredentials)
+                .endpoint(Constants.BACKEND_URL)
+                .build();
+        this.fulfillmentOrdersApi = new FulfillmentOrdersApi.Builder()
+                .lwaAuthorizationCredentials(lwaCredentials)
+                .endpoint(Constants.BACKEND_URL)
+                .build();
+    }
+
+    @Override
+    protected void start() {
+        System.out.println("======================================================================");
+        System.out.println("MCF (v2026-07-04) Create On-Hold and Ship Order Recipe");
+        System.out.println("======================================================================");
+
+        // Step 1 – Preview how the order will ship + fees
+        getOrderPreview();
+
+        // Step 2 – Create the order on HOLD
+        createOrderOnHold();
+        String orderId = McfConstants.SAMPLE_ORDER_ID;
+
+        // Step 3 – Release the held order for shipment
+        updateOrderToShip(orderId);
+
+        // Step 4 – Confirm the order was released from hold
+        getOrder(orderId);
+
+        System.out.println("\n======================================================================");
+        System.out.println("MCF create on-hold and ship order workflow completed successfully.");
+        System.out.println("======================================================================");
+    }
+
+    // -- Step 1: Get Order Preview --------------------------------------------
+
+    /**
+     * Call getOrderPreview to preview shipment split, weight, and fees before committing.
+     */
+    private GetOrderPreviewResponse getOrderPreview() {
+        System.out.println("\n--- Step 1: Get Order Preview ---");
+        try {
+            // SDK 1.11.1: getOrderPreview(GetOrderPreviewRequest body, String xAmznFulfillmentServiceId)
+            GetOrderPreviewResponse response = fulfillmentPreviewsApi.getOrderPreview(
+                    McfConstants.samplePreviewRequest(), null);
+            System.out.println("Order preview retrieved successfully.");
+            return response;
+        } catch (Exception e) {
+            System.err.println("Error getting order preview: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    // -- Step 2: Create Order on HOLD -----------------------------------------
+
+    /**
+     * Call createOrder with fulfillmentConfiguration.action = HOLD so the order is
+     * accepted and reserved, but NOT shipped yet.
+     */
+    private CreateOrderResponse createOrderOnHold() {
+        System.out.println("\n--- Step 2: Create Order (action=HOLD) ---");
+        try {
+            // SDK 1.11.1: createOrder(CreateOrderRequest body, String xAmznFulfillmentServiceId)
+            CreateOrderResponse response = fulfillmentOrdersApi.createOrder(
+                    McfConstants.sampleCreateOrderOnHoldRequest(), null);
+            System.out.println("On-hold order created: " + McfConstants.SAMPLE_ORDER_ID);
+            return response;
+        } catch (Exception e) {
+            System.err.println("Error creating on-hold order: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    // -- Step 3: Update Order to SHIP -----------------------------------------
+
+    /**
+     * Call updateOrder with fulfillmentConfiguration.action = SHIP to release the held
+     * order. In this version only the action is required in the body — no need to resend
+     * the full order. Returns HTTP 202 (Accepted).
+     */
+    private UpdateOrderResponse updateOrderToShip(String orderId) {
+        System.out.println("\n--- Step 3: Update Order (action=SHIP) ---");
+        try {
+            // SDK 1.11.1: updateOrder(UpdateOrderRequest body, String orderId, String xAmznFulfillmentServiceId)
+            UpdateOrderResponse response = fulfillmentOrdersApi.updateOrder(
+                    McfConstants.sampleUpdateOrderShipRequest(), orderId, null);
+            System.out.println("Ship request accepted for: " + orderId);
+            return response;
+        } catch (Exception e) {
+            System.err.println("Error updating order: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    // -- Step 4: Get Order ----------------------------------------------------
+
+    /**
+     * Call getOrder to confirm the order was released from hold and read its current
+     * status / shipments.
+     */
+    private GetOrderResponse getOrder(String orderId) {
+        System.out.println("\n--- Step 4: Get Order ---");
+        try {
+            // SDK 1.11.1: getOrder(String orderId, String xAmznFulfillmentServiceId, String shipments)
+            GetOrderResponse response = fulfillmentOrdersApi.getOrder(orderId, null, null);
+            System.out.println("Order details retrieved for: " + orderId);
+            return response;
+        } catch (Exception e) {
+            System.err.println("Error getting order: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/code-recipes/java/src/main/java/multichannel_fulfillment/fulfillment_outbound_v2/McfProductPageAndCheckoutPreviewsRecipe.java
+++ b/code-recipes/java/src/main/java/multichannel_fulfillment/fulfillment_outbound_v2/McfProductPageAndCheckoutPreviewsRecipe.java
@@ -1,0 +1,141 @@
+package multichannel_fulfillment.fulfillment_outbound_v2;
+
+import software.amazon.spapi.api.fulfillment.outbound.v2026_07_04.FulfillmentPreviewsApi;
+import software.amazon.spapi.api.fulfillment.outbound.v2026_07_04.OffersApi;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.GetOffersResponse;
+import software.amazon.spapi.models.fulfillment.outbound.v2026_07_04.GetOrderPreviewResponse;
+import util.Constants;
+import util.Recipe;
+
+/**
+ * MCF (Fulfillment Outbound v2026-07-04) Product Page and Checkout Previews Recipe
+ * ================================================================================
+ *
+ * <p>This recipe demonstrates the two pre-order "preview" calls in this version of the
+ * API and when to use each. They answer different questions at different points in the
+ * shopper funnel:</p>
+ *
+ * <ol>
+ *   <li><b>getOffers</b> (product/cart page) — "When can the customer get it?"
+ *       Item-level delivery promise with an estimated delivery date range and an offer
+ *       expiry. Works with a variable-precision address (postal code + country) or even
+ *       just the shopper's IP. Fast and lightweight; does not return estimated fees.</li>
+ *   <li><b>getOrderPreview</b> (checkout review) — "How will it ship and what will it cost?"
+ *       Order-level preview that requires a full delivery address and returns planned
+ *       shipments (how the order splits), estimated shipping weight, delivery/ship
+ *       intervals, and estimated fees.</li>
+ * </ol>
+ *
+ * <p><b>Real-world notes:</b></p>
+ * <ul>
+ *   <li>Show getOffers results as a "Get it by &lt;date&gt;" badge early, at scale.</li>
+ *   <li>Call getOrderPreview once, at checkout, when you have the full address, to show
+ *       shipment breakdown and fees before committing the order.</li>
+ *   <li>Neither call reserves inventory or creates an order.</li>
+ * </ul>
+ *
+ * <p><b>DEVELOPER NOTES — Adapting this recipe for production:</b></p>
+ * <ol>
+ *   <li>Remove the {@code .endpoint(Constants.BACKEND_URL)} call in the API builders.
+ *       The SDK will automatically route to the correct SP-API endpoint.</li>
+ *   <li>Replace the placeholder LWA credentials in the base {@code Recipe} class
+ *       with your real credentials, ideally loaded from environment variables.</li>
+ *   <li>Update the sample payloads in {@code McfConstants} with real SKUs and addresses.</li>
+ * </ol>
+ *
+ * <p>API version: Fulfillment Outbound v2026-07-04</p>
+ */
+public class McfProductPageAndCheckoutPreviewsRecipe extends Recipe {
+
+    private final OffersApi offersApi;
+    private final FulfillmentPreviewsApi fulfillmentPreviewsApi;
+
+    public McfProductPageAndCheckoutPreviewsRecipe() {
+        // DEVELOPER NOTE: For production, remove .endpoint(Constants.BACKEND_URL)
+        this.offersApi = new OffersApi.Builder()
+                .lwaAuthorizationCredentials(lwaCredentials)
+                .endpoint(Constants.BACKEND_URL)
+                .build();
+        this.fulfillmentPreviewsApi = new FulfillmentPreviewsApi.Builder()
+                .lwaAuthorizationCredentials(lwaCredentials)
+                .endpoint(Constants.BACKEND_URL)
+                .build();
+    }
+
+    @Override
+    protected void start() {
+        System.out.println("======================================================================");
+        System.out.println("MCF (v2026-07-04) Product Page and Checkout Previews Recipe");
+        System.out.println("======================================================================");
+
+        // Step 1 – Product-page delivery promise
+        getOffers();
+
+        // Step 2 – Checkout-review shipment split + fees
+        getOrderPreview();
+
+        System.out.println("\n======================================================================");
+        System.out.println("MCF product page and checkout previews workflow completed successfully.");
+        System.out.println("======================================================================");
+    }
+
+    // -- Step 1: Get Offers (product-page delivery promise) -------------------
+
+    /**
+     * Call getOffers to retrieve per-item delivery options (estimated delivery date
+     * range + offer expiry).
+     *
+     * <p>Key fields in the response:</p>
+     * <ul>
+     *   <li>offerResults[].item.productIdentifier.amazonSku</li>
+     *   <li>offerResults[].offers[].expiryTime</li>
+     *   <li>offerResults[].offers[].fulfillmentConfiguration.serviceLevel.serviceTier</li>
+     *   <li>offerResults[].offers[].fulfillmentConfiguration.serviceLevel.deliveryInterval
+     *       (startTime / endTime)</li>
+     *   <li>offerResults[].constraints[] (e.g., item out of stock — no offers)</li>
+     * </ul>
+     */
+    private GetOffersResponse getOffers() {
+        System.out.println("\n--- Step 1: Get Offers (product-page delivery promise) ---");
+        try {
+            // SDK 1.11.1: getOffers(GetOffersRequest body, String xAmznFulfillmentServiceId)
+            GetOffersResponse response = offersApi.getOffers(
+                    McfConstants.sampleOffersRequest(), null);
+            System.out.println("Offers retrieved successfully.");
+            return response;
+        } catch (Exception e) {
+            System.err.println("Error getting offers: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    // -- Step 2: Get Order Preview (checkout preview) -------------------------
+
+    /**
+     * Call getOrderPreview to retrieve the order-level breakdown: how the order splits
+     * into planned shipments, estimated weight, delivery/ship intervals, and estimated fees.
+     *
+     * <p>Key fields in the response:</p>
+     * <ul>
+     *   <li>plannedShipments[].estimatedShippingWeight</li>
+     *   <li>plannedShipments[].items[]</li>
+     *   <li>plannedShipments[].offers[].fulfillmentConfiguration.serviceLevel
+     *       (serviceTier, deliveryInterval, shipInterval)</li>
+     *   <li>plannedShipments[].offers[].estimatedPrice.rollupPrices[] / totalPrice</li>
+     *   <li>constraints[] (anything preventing fulfillment)</li>
+     * </ul>
+     */
+    private GetOrderPreviewResponse getOrderPreview() {
+        System.out.println("\n--- Step 2: Get Order Preview (checkout review) ---");
+        try {
+            // SDK 1.11.1: getOrderPreview(GetOrderPreviewRequest body, String xAmznFulfillmentServiceId)
+            GetOrderPreviewResponse response = fulfillmentPreviewsApi.getOrderPreview(
+                    McfConstants.samplePreviewRequest(), null);
+            System.out.println("Order preview retrieved successfully.");
+            return response;
+        } catch (Exception e) {
+            System.err.println("Error getting order preview: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/code-recipes/java/src/test/java/multichannel_fulfillment/fulfillment_outbound_v2/McfCreateAndCancelOrderRecipeTest.java
+++ b/code-recipes/java/src/test/java/multichannel_fulfillment/fulfillment_outbound_v2/McfCreateAndCancelOrderRecipeTest.java
@@ -1,0 +1,23 @@
+package multichannel_fulfillment.fulfillment_outbound_v2;
+
+import util.RecipeTest;
+
+import java.util.List;
+
+/**
+ * Test for the MCF (v2026-07-04) Create and Cancel Order Recipe.
+ * Workflow: getOrderPreview -> createOrder -> cancelOrder.
+ */
+public class McfCreateAndCancelOrderRecipeTest extends RecipeTest {
+
+    protected McfCreateAndCancelOrderRecipeTest() {
+        super(
+                new McfCreateAndCancelOrderRecipe(),
+                List.of(
+                        "mcf-v2-getOrderPreview",
+                        "mcf-v2-createOrder",
+                        "mcf-v2-cancelOrder"
+                )
+        );
+    }
+}

--- a/code-recipes/java/src/test/java/multichannel_fulfillment/fulfillment_outbound_v2/McfCreateAndTrackOrderRecipeTest.java
+++ b/code-recipes/java/src/test/java/multichannel_fulfillment/fulfillment_outbound_v2/McfCreateAndTrackOrderRecipeTest.java
@@ -1,0 +1,24 @@
+package multichannel_fulfillment.fulfillment_outbound_v2;
+
+import util.RecipeTest;
+
+import java.util.List;
+
+/**
+ * Test for the MCF (v2026-07-04) Create and Track Order Recipe.
+ * Workflow: getOrderPreview -> createOrder -> listOrders -> getOrder (embedded tracking).
+ */
+public class McfCreateAndTrackOrderRecipeTest extends RecipeTest {
+
+    protected McfCreateAndTrackOrderRecipeTest() {
+        super(
+                new McfCreateAndTrackOrderRecipe(),
+                List.of(
+                        "mcf-v2-getOrderPreview",
+                        "mcf-v2-createOrder",
+                        "mcf-v2-listOrders",
+                        "mcf-v2-getOrder"
+                )
+        );
+    }
+}

--- a/code-recipes/java/src/test/java/multichannel_fulfillment/fulfillment_outbound_v2/McfCreateOnHoldAndShipOrderRecipeTest.java
+++ b/code-recipes/java/src/test/java/multichannel_fulfillment/fulfillment_outbound_v2/McfCreateOnHoldAndShipOrderRecipeTest.java
@@ -1,0 +1,24 @@
+package multichannel_fulfillment.fulfillment_outbound_v2;
+
+import util.RecipeTest;
+
+import java.util.List;
+
+/**
+ * Test for the MCF (v2026-07-04) Create On-Hold and Ship Order Recipe.
+ * Workflow: getOrderPreview -> createOrder (HOLD) -> updateOrder (SHIP) -> getOrder.
+ */
+public class McfCreateOnHoldAndShipOrderRecipeTest extends RecipeTest {
+
+    protected McfCreateOnHoldAndShipOrderRecipeTest() {
+        super(
+                new McfCreateOnHoldAndShipOrderRecipe(),
+                List.of(
+                        "mcf-v2-getOrderPreview",
+                        "mcf-v2-createOrder",
+                        "mcf-v2-updateOrder",
+                        "mcf-v2-getOrder"
+                )
+        );
+    }
+}

--- a/code-recipes/java/src/test/java/multichannel_fulfillment/fulfillment_outbound_v2/McfProductPageAndCheckoutPreviewsRecipeTest.java
+++ b/code-recipes/java/src/test/java/multichannel_fulfillment/fulfillment_outbound_v2/McfProductPageAndCheckoutPreviewsRecipeTest.java
@@ -1,0 +1,22 @@
+package multichannel_fulfillment.fulfillment_outbound_v2;
+
+import util.RecipeTest;
+
+import java.util.List;
+
+/**
+ * Test for the MCF (v2026-07-04) Product Page and Checkout Previews Recipe.
+ * Workflow: getOffers (product page) -> getOrderPreview (checkout review).
+ */
+public class McfProductPageAndCheckoutPreviewsRecipeTest extends RecipeTest {
+
+    protected McfProductPageAndCheckoutPreviewsRecipeTest() {
+        super(
+                new McfProductPageAndCheckoutPreviewsRecipe(),
+                List.of(
+                        "mcf-v2-getOffers",
+                        "mcf-v2-getOrderPreview"
+                )
+        );
+    }
+}


### PR DESCRIPTION
Adds 4 Java recipes (product page & checkout previews, create & track, create & cancel, create on-hold & ship) plus a shared constants file and 4 tests, mirroring the published Python v2026-07-04 set.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
